### PR TITLE
Do not track apig binary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,7 +27,7 @@ _testmain.go
 *.test
 *.prof
 
-/api-server-generator
+/apig
 /bin/
 
 /bindata.go


### PR DESCRIPTION
## WHY
Binary built by simple `go build` should not be included in Git repository.

## WHAT
Add `apig` to `.gitignore`. I missed this modification at #15 .