### PR TITLE
Do fetching deps and building binary simultaneously

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,7 @@ bin/$(BINARY): deps $(SOURCES)
 .PHONY: clean
 clean:
 	rm -fr bin/*
+	rm -fr vendor/*
 
 .PHONY: deps
 deps: glide

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ GLIDE_VERSION := 0.11.0
 
 .DEFAULT_GOAL := bin/$(BINARY)
 
-bin/$(BINARY): $(SOURCES)
+bin/$(BINARY): deps $(SOURCES)
 	go generate
 	go build $(LDFLAGS) -o bin/$(BINARY)
 

--- a/README.md
+++ b/README.md
@@ -25,8 +25,9 @@ If you're using Go 1.5, `GO15VENDOREXPERIMENT=1` must be set.
 
 ### How to build
 
+`make` generates binary into `bin/apig`.
+
 ```bash
-$ make deps
 $ make
 ```
 


### PR DESCRIPTION
from #25

## WHY
Current build process does not follow the usual way. Is `make deps` really needed?

```bash
$ make deps
$ make 
```

## WHAT
Do `make deps` in default `make` target internally.

After applying this patch, we can build binary more simply:

```bash
$ make
```