### PR TITLE
Convert model name to snake_case for filename

### DIFF
--- a/_templates/router.go.tmpl
+++ b/_templates/router.go.tmpl
@@ -10,11 +10,11 @@ func Initialize(r *gin.Engine) {
 	api := r.Group("api")
 	{
 {{ range .Models }}
-		api.GET("/{{ pluralize (tolower .Name) }}", controllers.Get{{ pluralize .Name }})
-		api.GET("/{{ pluralize (tolower .Name) }}/:id", controllers.Get{{ .Name }})
-		api.POST("/{{ pluralize (tolower .Name) }}", controllers.Create{{ .Name }})
-		api.PUT("/{{ pluralize (tolower .Name) }}/:id", controllers.Update{{ .Name }})
-		api.DELETE("/{{ pluralize (tolower .Name) }}/:id", controllers.Delete{{ .Name }})
+		api.GET("/{{ pluralize (toSnakeCase .Name) }}", controllers.Get{{ pluralize .Name }})
+		api.GET("/{{ pluralize (toSnakeCase .Name) }}/:id", controllers.Get{{ .Name }})
+		api.POST("/{{ pluralize (toSnakeCase .Name) }}", controllers.Create{{ .Name }})
+		api.PUT("/{{ pluralize (toSnakeCase .Name) }}/:id", controllers.Update{{ .Name }})
+		api.DELETE("/{{ pluralize (toSnakeCase .Name) }}/:id", controllers.Delete{{ .Name }})
 {{ end }}
 	}
 }

--- a/generator.go
+++ b/generator.go
@@ -6,6 +6,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"text/template"
 
@@ -20,6 +21,7 @@ var funcMap = template.FuncMap{
 	"pluralize":        inflector.Pluralize,
 	"requestParams":    requestParams,
 	"tolower":          strings.ToLower,
+	"toSnakeCase":      toSnakeCase,
 	"title":            strings.Title,
 }
 
@@ -44,6 +46,16 @@ var managedFields = []string{
 	"ID",
 	"CreatedAt",
 	"UpdatedAt",
+}
+
+var matchFirstCap = regexp.MustCompile("(.)([A-Z][a-z]+)")
+var matchAllCap = regexp.MustCompile("([a-z0-9])([A-Z])")
+
+// code from https://gist.github.com/stoewer/fbe273b711e6a06315d19552dd4d33e6
+func toSnakeCase(str string) string {
+	snake := matchFirstCap.ReplaceAllString(str, "${1}_${2}")
+	snake = matchAllCap.ReplaceAllString(snake, "${1}_${2}")
+	return strings.ToLower(snake)
 }
 
 func apibDefaultValue(field *Field) string {
@@ -166,7 +178,7 @@ func generateApibModel(detail *Detail, outDir string) error {
 		return err
 	}
 
-	dstPath := filepath.Join(outDir, "docs", strings.ToLower(detail.Model.Name)+".apib")
+	dstPath := filepath.Join(outDir, "docs", toSnakeCase(detail.Model.Name)+".apib")
 
 	if !fileExists(filepath.Dir(dstPath)) {
 		if err := mkdir(filepath.Dir(dstPath)); err != nil {
@@ -246,7 +258,7 @@ func generateController(detail *Detail, outDir string) error {
 		return err
 	}
 
-	dstPath := filepath.Join(outDir, "controllers", strings.ToLower(detail.Model.Name)+".go")
+	dstPath := filepath.Join(outDir, "controllers", toSnakeCase(detail.Model.Name)+".go")
 
 	if !fileExists(filepath.Dir(dstPath)) {
 		if err := mkdir(filepath.Dir(dstPath)); err != nil {

--- a/generator_test.go
+++ b/generator_test.go
@@ -66,7 +66,7 @@ func TestGenerateApibIndex(t *testing.T) {
 	defer os.RemoveAll(outDir)
 
 	if err := generateApibIndex(detail, outDir); err != nil {
-		t.Fatalf("Error should not be raised: %#v", err)
+		t.Fatalf("Error should not be raised: %s", err)
 	}
 
 	path := filepath.Join(outDir, "docs", "index.apib")
@@ -92,7 +92,7 @@ func TestGenerateApibModel(t *testing.T) {
 	defer os.RemoveAll(outDir)
 
 	if err := generateApibModel(detail, outDir); err != nil {
-		t.Fatalf("Error should not be raised: %#v", err)
+		t.Fatalf("Error should not be raised: %s", err)
 	}
 
 	path := filepath.Join(outDir, "docs", "user.apib")
@@ -120,7 +120,7 @@ func TestGenerateSkeleton(t *testing.T) {
 	outDir := filepath.Join(tempDir, "api-server")
 
 	if err := generateSkeleton(detail, outDir); err != nil {
-		t.Fatalf("Error should not be raised: %#v", err)
+		t.Fatalf("Error should not be raised: %s", err)
 	}
 
 	files := []string{
@@ -155,7 +155,7 @@ func TestGenerateController(t *testing.T) {
 	defer os.RemoveAll(outDir)
 
 	if err := generateController(detail, outDir); err != nil {
-		t.Fatalf("Error should not be raised: %#v", err)
+		t.Fatalf("Error should not be raised: %s", err)
 	}
 
 	path := filepath.Join(outDir, "controllers", "user.go")
@@ -181,7 +181,7 @@ func TestGenerateREADME(t *testing.T) {
 	defer os.RemoveAll(outDir)
 
 	if err := generateREADME([]*Model{userModel}, outDir); err != nil {
-		t.Fatalf("Error should not be raised: %#v", err)
+		t.Fatalf("Error should not be raised: %s", err)
 	}
 
 	path := filepath.Join(outDir, "README.md")
@@ -207,7 +207,7 @@ func TestGenerateRouter(t *testing.T) {
 	defer os.RemoveAll(outDir)
 
 	if err := generateRouter(detail, outDir); err != nil {
-		t.Fatalf("Error should not be raised: %#v", err)
+		t.Fatalf("Error should not be raised: %s", err)
 	}
 
 	path := filepath.Join(outDir, "router", "router.go")


### PR DESCRIPTION
## WHY
Now we just convert all chars in model name to lower case for filename and endpoint. However this is not suitable for multi-word model name.

For example, from `AccountName` model , `accountname.go` and `/api/accountname/` endpoint are generated.

## WHAT
Convert model name to snake_case for filename and endpoint.

For example, from `AccountName` model , `account_name.go` and `/api/account_name/` endpoint are generated.

`toSnakeCase` function is originated in https://gist.github.com/stoewer/fbe273b711e6a06315d19552dd4d33e6 .