### PR TITLE
Support automigrate

### DIFF
--- a/_templates/db.go.tmpl
+++ b/_templates/db.go.tmpl
@@ -24,7 +24,9 @@ func Connect() *gorm.DB {
 	}
 
 	if os.Getenv("AUTOMIGRATE") == "true" {
-		db.AutoMigrate({{ range $key, $value := .Models }}{{ if $key }}, {{ end }}&models.{{ $value.Name }}{}{{ end }})
+		db.AutoMigrate({{ range .Models }}
+			&models.{{ .Name }}{},{{ end }}
+		)
 	}
 	return db
 }

--- a/_templates/db.go.tmpl
+++ b/_templates/db.go.tmpl
@@ -5,6 +5,8 @@ import (
 	"os"
 	"path/filepath"
 
+	"{{ .ImportDir }}/models"
+
 	"github.com/gin-gonic/gin"
 	"github.com/jinzhu/gorm"
 	_ "github.com/jinzhu/gorm/dialects/sqlite"
@@ -19,6 +21,10 @@ func Connect() *gorm.DB {
 	db.LogMode(false)
 	if os.Getenv("DB") == "DEBUG" {
 		db.LogMode(true)
+	}
+
+	if os.Getenv("AUTOMIGRATE") == "true" {
+		db.AutoMigrate({{ range $key, $value := .Models }}{{ if $key }}, {{ end }}&models.{{ $value.Name }}{}{{ end }})
 	}
 	return db
 }

--- a/generator.go
+++ b/generator.go
@@ -346,3 +346,39 @@ func generateRouter(detail *Detail, outDir string) error {
 
 	return nil
 }
+
+func generateDB(detail *Detail, outDir string) error {
+	body, err := Asset(filepath.Join(templateDir, "db.go.tmpl"))
+
+	if err != nil {
+		return err
+	}
+
+	tmpl, err := template.New("db").Funcs(funcMap).Parse(string(body))
+
+	if err != nil {
+		return err
+	}
+
+	var buf bytes.Buffer
+
+	if err := tmpl.Execute(&buf, detail); err != nil {
+		return err
+	}
+
+	dstPath := filepath.Join(outDir, "db", "db.go")
+
+	if !fileExists(filepath.Dir(dstPath)) {
+		if err := mkdir(filepath.Dir(dstPath)); err != nil {
+			return err
+		}
+	}
+
+	if err := ioutil.WriteFile(dstPath, buf.Bytes(), 0644); err != nil {
+		return err
+	}
+
+	fmt.Fprintf(os.Stdout, "\t\x1b[32m%s\x1b[0m %s\n", "update", dstPath)
+
+	return nil
+}

--- a/main.go
+++ b/main.go
@@ -228,6 +228,11 @@ func cmdGen(outDir string) {
 		os.Exit(1)
 	}
 
+	if err := generateDB(detail, outDir); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+
 	if err := generateREADME(models, outDir); err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)


### PR DESCRIPTION
## WHY
For easy to use.

## WHAT
Add auto migration rogic to ``db/db.go``

### Usage
```
>>> AUTOMIGRATE=true go run main.go
```