### PR TITLE
Solider parse of github username

### DIFF
--- a/main.go
+++ b/main.go
@@ -89,8 +89,8 @@ Options:
 
 			if err != nil {
 				username, err = gitconfig.Username()
-				if err != nil {
-					msg := "Cannot find `~/.gitconfig` file.\n" +
+				if err != nil || strings.Contains(username, " ") {
+					msg := "Cannot find github username in `~/.gitconfig` file.\n" +
 						"Please use -u option"
 					fmt.Println(msg)
 					os.Exit(1)


### PR DESCRIPTION
## WHY

To solve #25 

```
apig new apig-sample
    create /Users/awakia/src/github.com/Naoyoshi Aikawa/apig-sample/README.md
    create /Users/awakia/src/github.com/Naoyoshi Aikawa/apig-sample/.gitignore
    create /Users/awakia/src/github.com/Naoyoshi Aikawa/apig-sample/main.go
    create /Users/awakia/src/github.com/Naoyoshi Aikawa/apig-sample/db/db.go
    create /Users/awakia/src/github.com/Naoyoshi Aikawa/apig-sample/db/pagination.go
    create /Users/awakia/src/github.com/Naoyoshi Aikawa/apig-sample/router/router.go
    create /Users/awakia/src/github.com/Naoyoshi Aikawa/apig-sample/middleware/set_db.go
    create /Users/awakia/src/github.com/Naoyoshi Aikawa/apig-sample/server/server.go
    create /Users/awakia/src/github.com/Naoyoshi Aikawa/apig-sample/helper/field.go
    create /Users/awakia/src/github.com/Naoyoshi Aikawa/apig-sample/version/version.go
    create /Users/awakia/src/github.com/Naoyoshi Aikawa/apig-sample/version/version_test.go
    create /Users/awakia/src/github.com/Naoyoshi Aikawa/apig-sample/controllers/.gitkeep
    create /Users/awakia/src/github.com/Naoyoshi Aikawa/apig-sample/docs/.gitkeep
    create /Users/awakia/src/github.com/Naoyoshi Aikawa/apig-sample/models/.gitkeep
===> Created /Users/awakia/src/github.com/Naoyoshi Aikawa/apig-sample
```


## WHAT

Do not judge name as github user name if name contains space.