### PR TITLE
Define preload scope dynamically

### DIFF
--- a/_templates/controller.go.tmpl
+++ b/_templates/controller.go.tmpl
@@ -14,24 +14,6 @@ import (
 	"github.com/serenize/snaker"
 )
 
-func set{{ .Model.Name }}Preloads(preloads string, db *gorm.DB) *gorm.DB {
-	if preloads == "" {
-		return db
-	}
-
-	for _, preload := range strings.Split(preloads, ",") {
-		var a []string
-
-		for _, s := range strings.Split(preload, ".") {
-			a = append(a, snaker.SnakeToCamel(s))
-		}
-
-		db = db.Preload(strings.Join(a, "."))
-	}
-
-	return db
-}
-
 func Get{{ pluralize .Model.Name }}(c *gin.Context) {
 	ver, err := version.New(c)
 	if err != nil {
@@ -50,7 +32,7 @@ func Get{{ pluralize .Model.Name }}(c *gin.Context) {
 		return
 	}
 
-	db = set{{ .Model.Name }}Preloads(preloads, db)
+	db = dbpkg.SetPreloads(preloads, db)
 
 	var {{ pluralize (tolower .Model.Name) }} []models.{{ .Model.Name }}
 	if err := db.Select("*").Find(&{{ pluralize (tolower .Model.Name) }}).Error; err != nil {
@@ -91,7 +73,7 @@ func Get{{ .Model.Name }}(c *gin.Context) {
 	fields, nestFields := helper.ParseFields(c.DefaultQuery("fields", "*"))
 
 	db := dbpkg.DBInstance(c)
-	db = set{{ .Model.Name }}Preloads(preloads, db)
+	db = dbpkg.SetPreloads(preloads, db)
 
 	var {{ tolower .Model.Name }} models.{{ .Model.Name }}
 	if err := db.Select("*").First(&{{ tolower .Model.Name }}, id).Error; err != nil {

--- a/_templates/controller.go.tmpl
+++ b/_templates/controller.go.tmpl
@@ -2,7 +2,6 @@ package controllers
 
 import (
 	"net/http"
-	"strings"
 
 	dbpkg "{{ .ImportDir }}/db"
 	"{{ .ImportDir }}/helper"
@@ -10,8 +9,6 @@ import (
 	"{{ .ImportDir }}/version"
 
 	"github.com/gin-gonic/gin"
-	"github.com/jinzhu/gorm"
-	"github.com/serenize/snaker"
 )
 
 func Get{{ pluralize .Model.Name }}(c *gin.Context) {

--- a/_templates/controller.go.tmpl
+++ b/_templates/controller.go.tmpl
@@ -2,6 +2,7 @@ package controllers
 
 import (
 	"net/http"
+	"strings"
 
 	dbpkg "{{ .ImportDir }}/db"
 	"{{ .ImportDir }}/helper"
@@ -10,33 +11,25 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/jinzhu/gorm"
+	"github.com/serenize/snaker"
 )
 
-func set{{ .Model.Name }}Preload(fields []string, db *gorm.DB) ([]string, *gorm.DB) {
-	sel := make([]string, len(fields))
-	copy(sel, fields)
-	offset := 0
-	for key, val := range fields {
-		switch val {
-{{ range .Model.Fields }}{{ if .IsAssociation }}
-		case "{{ .JSONName }}":
-			db = db.Preload("{{ .Name }}")
-			sel = append(sel[:(key-offset)], sel[(key+1-offset):]...)
-			offset += 1
-			idflag := true
-			for _, v := range sel {
-				if v == "{{ if .IsBelongsTo }}{{ .JSONName }}_id{{ else }}id{{ end }}" {
-					idflag = false
-					break
-				}
-			}
-			if idflag {
-				sel = append(sel, "{{ if .IsBelongsTo }}{{ .JSONName }}_id{{ else }}id{{ end }}")
-			}
-{{ end }}{{ end }}
-		}
+func set{{ .Model.Name }}Preloads(preloads string, db *gorm.DB) *gorm.DB {
+	if preloads == "" {
+		return db
 	}
-	return sel, db
+
+	for _, preload := range strings.Split(preloads, ",") {
+		var a []string
+
+		for _, s := range strings.Split(preload, ".") {
+			a = append(a, snaker.SnakeToCamel(s))
+		}
+
+		db = db.Preload(strings.Join(a, "."))
+	}
+
+	return db
 }
 
 func Get{{ pluralize .Model.Name }}(c *gin.Context) {
@@ -46,6 +39,9 @@ func Get{{ pluralize .Model.Name }}(c *gin.Context) {
 		return
 	}
 
+	preloads := c.DefaultQuery("preloads", "")
+	fields, nestFields := helper.ParseFields(c.DefaultQuery("fields", "*"))
+
 	pagination := dbpkg.Pagination{}
 	db, err := pagination.Paginate(c)
 
@@ -54,12 +50,10 @@ func Get{{ pluralize .Model.Name }}(c *gin.Context) {
 		return
 	}
 
-	fields, nestFields := helper.ParseFields(c.DefaultQuery("fields", "*"))
-	sel, db := set{{ .Model.Name }}Preload(fields, db)
-	var {{ pluralize (tolower .Model.Name) }} []models.{{ .Model.Name }}
-	err = db.Select(sel).Find(&{{ pluralize (tolower .Model.Name) }}).Error
+	db = set{{ .Model.Name }}Preloads(preloads, db)
 
-	if err != nil {
+	var {{ pluralize (tolower .Model.Name) }} []models.{{ .Model.Name }}
+	if err := db.Select("*").Find(&{{ pluralize (tolower .Model.Name) }}).Error; err != nil {
 		c.JSON(500, gin.H{"error": "error occured"})
 		return
 	}
@@ -92,13 +86,15 @@ func Get{{ .Model.Name }}(c *gin.Context) {
 		return
 	}
 
-	db := dbpkg.DBInstance(c)
 	id := c.Params.ByName("id")
+	preloads := c.DefaultQuery("preloads", "")
 	fields, nestFields := helper.ParseFields(c.DefaultQuery("fields", "*"))
-	sel, db := set{{ .Model.Name }}Preload(fields, db)
-	var {{ tolower .Model.Name }} models.{{ .Model.Name }}
 
-	if db.Select(sel).First(&{{ tolower .Model.Name }}, id).Error != nil {
+	db := dbpkg.DBInstance(c)
+	db = set{{ .Model.Name }}Preloads(preloads, db)
+
+	var {{ tolower .Model.Name }} models.{{ .Model.Name }}
+	if err := db.Select("*").First(&{{ tolower .Model.Name }}, id).Error; err != nil {
 		content := gin.H{"error": "{{ tolower .Model.Name }} with id#" + id + " not found"}
 		c.JSON(404, content)
 		return

--- a/_templates/db.go.tmpl
+++ b/_templates/db.go.tmpl
@@ -4,12 +4,14 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"{{ .ImportDir }}/models"
 
 	"github.com/gin-gonic/gin"
 	"github.com/jinzhu/gorm"
 	_ "github.com/jinzhu/gorm/dialects/sqlite"
+	"github.com/serenize/snaker"
 )
 
 func Connect() *gorm.DB {
@@ -33,4 +35,22 @@ func Connect() *gorm.DB {
 
 func DBInstance(c *gin.Context) *gorm.DB {
 	return c.MustGet("DB").(*gorm.DB)
+}
+
+func SetPreloads(preloads string, db *gorm.DB) *gorm.DB {
+	if preloads == "" {
+		return db
+	}
+
+	for _, preload := range strings.Split(preloads, ",") {
+		var a []string
+
+		for _, s := range strings.Split(preload, ".") {
+			a = append(a, snaker.SnakeToCamel(s))
+		}
+
+		db = db.Preload(strings.Join(a, "."))
+	}
+
+	return db
 }

--- a/_templates/skeleton/db/db.go.tmpl
+++ b/_templates/skeleton/db/db.go.tmpl
@@ -4,10 +4,12 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/gin-gonic/gin"
 	"github.com/jinzhu/gorm"
 	_ "github.com/jinzhu/gorm/dialects/sqlite"
+	"github.com/serenize/snaker"
 )
 
 func Connect() *gorm.DB {

--- a/_templates/skeleton/db/db.go.tmpl
+++ b/_templates/skeleton/db/db.go.tmpl
@@ -26,3 +26,21 @@ func Connect() *gorm.DB {
 func DBInstance(c *gin.Context) *gorm.DB {
 	return c.MustGet("DB").(*gorm.DB)
 }
+
+func SetPreloads(preloads string, db *gorm.DB) *gorm.DB {
+	if preloads == "" {
+		return db
+	}
+
+	for _, preload := range strings.Split(preloads, ",") {
+		var a []string
+
+		for _, s := range strings.Split(preload, ".") {
+			a = append(a, snaker.SnakeToCamel(s))
+		}
+
+		db = db.Preload(strings.Join(a, "."))
+	}
+
+	return db
+}

--- a/generator_test.go
+++ b/generator_test.go
@@ -224,3 +224,29 @@ func TestGenerateRouter(t *testing.T) {
 		t.Fatalf("Failed to generate router correctly.\nexpected:\n%s\nactual:\n%s", string(c1), string(c2))
 	}
 }
+
+func TestGenerateDB(t *testing.T) {
+	outDir, err := ioutil.TempDir("", "generateDB")
+	if err != nil {
+		t.Fatal("Failed to create tempdir")
+	}
+	defer os.RemoveAll(outDir)
+
+	if err := generateDB(detail, outDir); err != nil {
+		t.Fatalf("Error should not be raised: %s", err)
+	}
+
+	path := filepath.Join(outDir, "db", "db.go")
+	_, err = os.Stat(path)
+	if err != nil {
+		t.Fatalf("Router file is not generated: %s", path)
+	}
+
+	fixture := filepath.Join("testdata", "db", "db.go")
+
+	if !compareFiles(path, fixture) {
+		c1, _ := ioutil.ReadFile(fixture)
+		c2, _ := ioutil.ReadFile(path)
+		t.Fatalf("Failed to generate db.go correctly.\nexpected:\n%s\nactual:\n%s", string(c1), string(c2))
+	}
+}

--- a/glide.lock
+++ b/glide.lock
@@ -1,8 +1,10 @@
-hash: 947bd12c6e998c51bf55cb14cc9ad039e9550b5210bbc50b79b92be113f23609
-updated: 2016-07-22T09:59:47.967544909+09:00
+hash: 940d575bdb04f73f7fb740517d5956c6861623c147e2ae45cdab81611f785dcd
+updated: 2016-07-22T20:48:44.491668499+09:00
 imports:
 - name: github.com/gedex/inflector
   version: 91797f1712fd58f224781be1080b8613d096187e
+- name: github.com/serenize/snaker
+  version: 8824b61eca66d308fcb2d515287d3d7a28dba8d6
 - name: github.com/tcnksm/go-gitconfig
   version: 6411ba19847f20afe47f603328d97aaeca6def6f
 testImports: []

--- a/glide.yaml
+++ b/glide.yaml
@@ -2,3 +2,4 @@ package: github.com/wantedly/apig
 import:
 - package: github.com/gedex/inflector
 - package: github.com/tcnksm/go-gitconfig
+- package: github.com/serenize/snaker

--- a/testdata/controllers/user.go
+++ b/testdata/controllers/user.go
@@ -2,6 +2,7 @@ package controllers
 
 import (
 	"net/http"
+	"strings"
 
 	dbpkg "github.com/wantedly/api-server/db"
 	"github.com/wantedly/api-server/helper"
@@ -10,20 +11,25 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/jinzhu/gorm"
+	"github.com/serenize/snaker"
 )
 
-func setUserPreload(fields []string, db *gorm.DB) ([]string, *gorm.DB) {
-	sel := make([]string, len(fields))
-	copy(sel, fields)
-	offset := 0
-	for key, val := range fields {
-		switch val {
-
-		case "*":
-			db = db
-		}
+func setUserPreloads(preloads string, db *gorm.DB) *gorm.DB {
+	if preloads == "" {
+		return db
 	}
-	return sel, db
+
+	for _, preload := range strings.Split(preloads, ",") {
+		var a []string
+
+		for _, s := range strings.Split(preload, ".") {
+			a = append(a, snaker.SnakeToCamel(s))
+		}
+
+		db = db.Preload(strings.Join(a, "."))
+	}
+
+	return db
 }
 
 func GetUsers(c *gin.Context) {
@@ -33,6 +39,9 @@ func GetUsers(c *gin.Context) {
 		return
 	}
 
+	preloads := c.DefaultQuery("preloads", "")
+	fields, nestFields := helper.ParseFields(c.DefaultQuery("fields", "*"))
+
 	pagination := dbpkg.Pagination{}
 	db, err := pagination.Paginate(c)
 
@@ -41,12 +50,10 @@ func GetUsers(c *gin.Context) {
 		return
 	}
 
-	fields, nestFields := helper.ParseFields(c.DefaultQuery("fields", "*"))
-	sel, db := setUserPreload(fields, db)
-	var users []models.User
-	err = db.Select(sel).Find(&users).Error
+	db = setUserPreloads(preloads, db)
 
-	if err != nil {
+	var users []models.User
+	if err := db.Select("*").Find(&users).Error; err != nil {
 		c.JSON(500, gin.H{"error": "error occured"})
 		return
 	}
@@ -79,13 +86,15 @@ func GetUser(c *gin.Context) {
 		return
 	}
 
-	db := dbpkg.DBInstance(c)
 	id := c.Params.ByName("id")
+	preloads := c.DefaultQuery("preloads", "")
 	fields, nestFields := helper.ParseFields(c.DefaultQuery("fields", "*"))
-	sel, db := setUserPreload(fields, db)
-	var user models.User
 
-	if db.Select(sel).First(&user, id).Error != nil {
+	db := dbpkg.DBInstance(c)
+	db = setUserPreloads(preloads, db)
+
+	var user models.User
+	if err := db.Select("*").First(&user, id).Error; err != nil {
 		content := gin.H{"error": "user with id#" + id + " not found"}
 		c.JSON(404, content)
 		return

--- a/testdata/controllers/user.go
+++ b/testdata/controllers/user.go
@@ -2,7 +2,6 @@ package controllers
 
 import (
 	"net/http"
-	"strings"
 
 	dbpkg "github.com/wantedly/api-server/db"
 	"github.com/wantedly/api-server/helper"
@@ -10,8 +9,6 @@ import (
 	"github.com/wantedly/api-server/version"
 
 	"github.com/gin-gonic/gin"
-	"github.com/jinzhu/gorm"
-	"github.com/serenize/snaker"
 )
 
 func GetUsers(c *gin.Context) {

--- a/testdata/controllers/user.go
+++ b/testdata/controllers/user.go
@@ -14,24 +14,6 @@ import (
 	"github.com/serenize/snaker"
 )
 
-func setUserPreloads(preloads string, db *gorm.DB) *gorm.DB {
-	if preloads == "" {
-		return db
-	}
-
-	for _, preload := range strings.Split(preloads, ",") {
-		var a []string
-
-		for _, s := range strings.Split(preload, ".") {
-			a = append(a, snaker.SnakeToCamel(s))
-		}
-
-		db = db.Preload(strings.Join(a, "."))
-	}
-
-	return db
-}
-
 func GetUsers(c *gin.Context) {
 	ver, err := version.New(c)
 	if err != nil {
@@ -50,7 +32,7 @@ func GetUsers(c *gin.Context) {
 		return
 	}
 
-	db = setUserPreloads(preloads, db)
+	db = dbpkg.SetPreloads(preloads, db)
 
 	var users []models.User
 	if err := db.Select("*").Find(&users).Error; err != nil {
@@ -91,7 +73,7 @@ func GetUser(c *gin.Context) {
 	fields, nestFields := helper.ParseFields(c.DefaultQuery("fields", "*"))
 
 	db := dbpkg.DBInstance(c)
-	db = setUserPreloads(preloads, db)
+	db = dbpkg.SetPreloads(preloads, db)
 
 	var user models.User
 	if err := db.Select("*").First(&user, id).Error; err != nil {

--- a/testdata/db/db.go
+++ b/testdata/db/db.go
@@ -1,0 +1,56 @@
+package db
+
+import (
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/wantedly/api-server/models"
+
+	"github.com/gin-gonic/gin"
+	"github.com/jinzhu/gorm"
+	_ "github.com/jinzhu/gorm/dialects/sqlite"
+	"github.com/serenize/snaker"
+)
+
+func Connect() *gorm.DB {
+	dir := filepath.Dir("db/database.db")
+	db, err := gorm.Open("sqlite3", dir+"/database.db")
+	if err != nil {
+		log.Fatalf("Got error when connect database, the error is '%v'", err)
+	}
+	db.LogMode(false)
+	if os.Getenv("DB") == "DEBUG" {
+		db.LogMode(true)
+	}
+
+	if os.Getenv("AUTOMIGRATE") == "true" {
+		db.AutoMigrate(
+			&models.User{},
+		)
+	}
+	return db
+}
+
+func DBInstance(c *gin.Context) *gorm.DB {
+	return c.MustGet("DB").(*gorm.DB)
+}
+
+func SetPreloads(preloads string, db *gorm.DB) *gorm.DB {
+	if preloads == "" {
+		return db
+	}
+
+	for _, preload := range strings.Split(preloads, ",") {
+		var a []string
+
+		for _, s := range strings.Split(preload, ".") {
+			a = append(a, snaker.SnakeToCamel(s))
+		}
+
+		db = db.Preload(strings.Join(a, "."))
+	}
+
+	return db
+}


### PR DESCRIPTION
## WHY
Now we fix the depth of preload to 2. We would like to fetch no nested fields by default, and specify the depth of preload as we like.

## WHAT
Add new request parameter `preloads` to specify tables to do preload. `fields` parameter is used for choosing fields including in response JSON only.

- If `preloads` parameter is empty, server does not do any preloads.
- `preloads` parameter should be comma-separated string with snake_case table name. Nested tables should be connected with dot. e.g. `profile`, `profile.nation`, `profile.nation,account_name`

Currently we does not specify deeply-nested fields at `fields` parameter (e.g. `profile.nation.name`), but I'll fix this at another branch.

## EXAMPLE
These examples show the behavior with new parameters.

https://gist.github.com/dtan4/97bb2867b869fd9bcda39cbfd3040feb