### PR TITLE
Return empty array if there is no record

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,5 @@ bindata.go
 
 /glide
 /vendor/
+
+/_example/_example

--- a/_example/controllers/company.go
+++ b/_example/controllers/company.go
@@ -51,7 +51,7 @@ func GetCompanies(c *gin.Context) {
 		// 1.0.0 <= this version < 2.0.0 !!
 	}
 
-	var fieldMap []map[string]interface{}
+	fieldMap := []map[string]interface{}{}
 	for key, _ := range companies {
 		fieldMap = append(fieldMap, helper.FieldToMap(companies[key], fields))
 	}

--- a/_example/controllers/email.go
+++ b/_example/controllers/email.go
@@ -51,7 +51,7 @@ func GetEmails(c *gin.Context) {
 		// 1.0.0 <= this version < 2.0.0 !!
 	}
 
-	var fieldMap []map[string]interface{}
+	fieldMap := []map[string]interface{}{}
 	for key, _ := range emails {
 		fieldMap = append(fieldMap, helper.FieldToMap(emails[key], fields))
 	}

--- a/_example/controllers/job.go
+++ b/_example/controllers/job.go
@@ -51,7 +51,7 @@ func GetJobs(c *gin.Context) {
 		// 1.0.0 <= this version < 2.0.0 !!
 	}
 
-	var fieldMap []map[string]interface{}
+	fieldMap := []map[string]interface{}{}
 	for key, _ := range jobs {
 		fieldMap = append(fieldMap, helper.FieldToMap(jobs[key], fields))
 	}

--- a/_example/controllers/profile.go
+++ b/_example/controllers/profile.go
@@ -51,7 +51,7 @@ func GetProfiles(c *gin.Context) {
 		// 1.0.0 <= this version < 2.0.0 !!
 	}
 
-	var fieldMap []map[string]interface{}
+	fieldMap := []map[string]interface{}{}
 	for key, _ := range profiles {
 		fieldMap = append(fieldMap, helper.FieldToMap(profiles[key], fields))
 	}

--- a/_example/controllers/user.go
+++ b/_example/controllers/user.go
@@ -51,7 +51,7 @@ func GetUsers(c *gin.Context) {
 		// 1.0.0 <= this version < 2.0.0 !!
 	}
 
-	var fieldMap []map[string]interface{}
+	fieldMap := []map[string]interface{}{}
 	for key, _ := range users {
 		fieldMap = append(fieldMap, helper.FieldToMap(users[key], fields))
 	}

--- a/_templates/controller.go.tmpl
+++ b/_templates/controller.go.tmpl
@@ -51,7 +51,7 @@ func Get{{ pluralize .Model.Name }}(c *gin.Context) {
 		// 1.0.0 <= this version < 2.0.0 !!
 	}
 
-	var fieldMap []map[string]interface{}
+	fieldMap := []map[string]interface{}{}
 	for key, _ := range {{ pluralize (tolower .Model.Name) }} {
 		fieldMap = append(fieldMap, helper.FieldToMap({{ pluralize (tolower .Model.Name) }}[key], fields))
 	}

--- a/apig/testdata/controllers/user.go
+++ b/apig/testdata/controllers/user.go
@@ -51,7 +51,7 @@ func GetUsers(c *gin.Context) {
 		// 1.0.0 <= this version < 2.0.0 !!
 	}
 
-	var fieldMap []map[string]interface{}
+	fieldMap := []map[string]interface{}{}
 	for key, _ := range users {
 		fieldMap = append(fieldMap, helper.FieldToMap(users[key], fields))
 	}


### PR DESCRIPTION
## WHY
When accessing to `GET /users/` endpoint and there is no user record, API server returns `null` instead of `[]`. This is not an appropriate response.

## WHAT
Return `[]` if there is no records.