### PR TITLE
Modify db log mode

### DIFF
--- a/_templates/db.go.tmpl
+++ b/_templates/db.go.tmpl
@@ -21,7 +21,7 @@ func Connect() *gorm.DB {
 		log.Fatalf("Got error when connect database, the error is '%v'", err)
 	}
 	db.LogMode(false)
-	if os.Getenv("DB") == "DEBUG" {
+	if gin.IsDebugging(){
 		db.LogMode(true)
 	}
 

--- a/_templates/skeleton/db/db.go.tmpl
+++ b/_templates/skeleton/db/db.go.tmpl
@@ -19,7 +19,7 @@ func Connect() *gorm.DB {
 		log.Fatalf("Got error when connect database, the error is '%v'", err)
 	}
 	db.LogMode(false)
-	if os.Getenv("DB") == "DEBUG" {
+	if gin.IsDebugging(){
 		db.LogMode(true)
 	}
 	return db


### PR DESCRIPTION
## WHY
I think db.Logmode should behave this way following the rails.

When debugging, db.logmode is true by default. 
When switching to release, db.logmode is false.

## WHAT
The condition of db.logmode  is changed from `os.Getenv(DB)=="DEBUG"` to `gin.IsDebugging()`

So switching to release is in the following code.

```
GIN_MODE=release bin/server
```
