### PR TITLE
Modify indent in server.go

### DIFF
--- a/_templates/skeleton/server/server.go.tmpl
+++ b/_templates/skeleton/server/server.go.tmpl
@@ -4,14 +4,14 @@ import (
 	"{{ .VCS }}/{{ .User }}/{{ .Project }}/middleware"
 	"{{ .VCS }}/{{ .User }}/{{ .Project }}/router"
 
-  "github.com/gin-gonic/gin"
-  "github.com/jinzhu/gorm"
-  _ "github.com/jinzhu/gorm/dialects/sqlite"
+	"github.com/gin-gonic/gin"
+	"github.com/jinzhu/gorm"
+	_ "github.com/jinzhu/gorm/dialects/sqlite"
 )
 
 func Setup(db *gorm.DB) *gin.Engine {
-  r := gin.Default()
-  r.Use(middleware.SetDBtoContext(db))
-  router.Initialize(r)
-  return r
+	r := gin.Default()
+	r.Use(middleware.SetDBtoContext(db))
+	router.Initialize(r)
+	return r
 }


### PR DESCRIPTION
## WHY
Indent in Go code should be hard-tab. However, generated `server.go` have soft-tab indents.

## WHAT
Modify indent in `server.go`