### PR TITLE
Specify namespace with apig gen --all

### DIFF
--- a/apig/generate.go
+++ b/apig/generate.go
@@ -314,7 +314,7 @@ func generateDB(detail *Detail, outDir string) error {
 	return nil
 }
 
-func Generate(outDir, modelDir, targetFile string, all bool) int {
+func Generate(outDir, modelDir, targetFile string, all bool, namespace string) int {
 	outModelDir := filepath.Join(outDir, modelDir)
 	files, err := ioutil.ReadDir(outModelDir)
 	if err != nil {
@@ -439,6 +439,7 @@ func Generate(outDir, modelDir, targetFile string, all bool) int {
 		VCS:       vcs,
 		User:      user,
 		Project:   project,
+		Namespace: namespace,
 	}
 	if all {
 		if err := generateSkeleton(detail, outDir); err != nil {

--- a/command/gen.go
+++ b/command/gen.go
@@ -19,7 +19,8 @@ const (
 type GenCommand struct {
 	Meta
 
-	all bool
+	all       bool
+	namespace string
 }
 
 func (c *GenCommand) Run(args []string) int {
@@ -38,7 +39,7 @@ func (c *GenCommand) Run(args []string) int {
 		fmt.Fprintln(os.Stderr, err)
 		return 1
 	}
-	return apig.Generate(wd, modelDir, targetFile, c.all)
+	return apig.Generate(wd, modelDir, targetFile, c.all, c.namespace)
 }
 
 func (c *GenCommand) parseArgs(args []string) error {
@@ -46,6 +47,8 @@ func (c *GenCommand) parseArgs(args []string) error {
 
 	flag.BoolVar(&c.all, "a", false, "Generate all skelton")
 	flag.BoolVar(&c.all, "all", false, "Generate all skelton")
+	flag.StringVar(&c.namespace, "n", "", "Namespace of API")
+	flag.StringVar(&c.namespace, "namespace", "", "Namespace of API")
 
 	if err := flag.Parse(args); err != nil {
 		return err
@@ -65,7 +68,8 @@ Usage: apig gen
   Generates controllers and more based on models
 
 Options:
-  -all, -a          Generate all boilerplate including new command generated code
+  -all, -a                    Generate all boilerplate including new command generated code
+  -namespace=namespace, -n    Namespace of API (default: "") [Use with --all, -a option]
 `
 	return strings.TrimSpace(helpText)
 }

--- a/command/new.go
+++ b/command/new.go
@@ -83,9 +83,9 @@ Usage: apig new PROJECTNAME
   Generate go project and its boilerplate
 
 Options:
-  -vcs=name, -v     Version controll system to use (default: github.com)
-  -user=name, -u    Username of VCS (default: username of github in .gitconfig)
-
+  -vcs=name, -v               Version control system to use (default: github.com)
+  -user=name, -u              Username of VCS (default: username of github in .gitconfig)
+  -namespace=namespace, -n    Namespace of API (default: "")
 `
 	return strings.TrimSpace(helpText)
 }


### PR DESCRIPTION
## WHY
When user executes `apig gen --all` at application repository, API namespace always rewrite as `""` (empty string).

## WHAT
Add `--namespace` option to `apig gen` command, like `apig new` command.

