### PR TITLE
Narrow fields in SQL query

### DIFF
--- a/_example/controllers/user.go
+++ b/_example/controllers/user.go
@@ -20,6 +20,7 @@ func GetUsers(c *gin.Context) {
 
 	preloads := c.DefaultQuery("preloads", "")
 	fields := helper.ParseFields(c.DefaultQuery("fields", "*"))
+	queryFields := helper.QueryFields(models.User{}, fields)
 
 	pagination := dbpkg.Pagination{}
 	db, err := pagination.Paginate(c)
@@ -32,7 +33,7 @@ func GetUsers(c *gin.Context) {
 	db = dbpkg.SetPreloads(preloads, db)
 
 	var users []models.User
-	if err := db.Select("*").Find(&users).Error; err != nil {
+	if err := db.Select(queryFields).Find(&users).Error; err != nil {
 		c.JSON(400, gin.H{"error": err.Error()})
 		return
 	}
@@ -68,12 +69,13 @@ func GetUser(c *gin.Context) {
 	id := c.Params.ByName("id")
 	preloads := c.DefaultQuery("preloads", "")
 	fields := helper.ParseFields(c.DefaultQuery("fields", "*"))
+	queryFields := helper.QueryFields(models.User{}, fields)
 
 	db := dbpkg.DBInstance(c)
 	db = dbpkg.SetPreloads(preloads, db)
 
 	var user models.User
-	if err := db.Select("*").First(&user, id).Error; err != nil {
+	if err := db.Select(queryFields).First(&user, id).Error; err != nil {
 		content := gin.H{"error": "user with id#" + id + " not found"}
 		c.JSON(404, content)
 		return

--- a/_example/helper/field_test.go
+++ b/_example/helper/field_test.go
@@ -4,6 +4,87 @@ import (
 	"testing"
 )
 
+type User struct {
+	ID      uint     `json:"id"`
+	Jobs    []*Job   `json:"jobs"`
+	Name    string   `json:"name"`
+	Profile *Profile `json:"profile"`
+}
+
+type Profile struct {
+	ID      uint  `json:"id"`
+	UserID  uint  `json:"user_id"`
+	User    *User `json:"user"`
+	Engaged bool  `json:"engaged"`
+}
+
+type Job struct {
+	ID     uint  `json:"id"`
+	UserID uint  `json:"user_id"`
+	User   *User `json:"user"`
+	RoleCd uint  `json:"role_cd"`
+}
+
+func TestQueryFields_Wildcard(t *testing.T) {
+	fields := map[string]interface{}{"*": nil}
+	result := QueryFields(User{}, fields)
+	expected := "*"
+
+	if result != expected {
+		t.Fatalf("result should be %s. actual: %s", expected, result)
+	}
+}
+
+func TestQueryFields_Primitive(t *testing.T) {
+	fields := map[string]interface{}{"name": nil}
+	result := QueryFields(User{}, fields)
+	expected := "name"
+
+	if result != expected {
+		t.Fatalf("result should be %s. actual: %s", expected, result)
+	}
+}
+
+func TestQueryFields_Multiple(t *testing.T) {
+	fields := map[string]interface{}{"id": nil, "name": nil}
+	result := QueryFields(User{}, fields)
+	expected := "id,name"
+
+	if result != expected {
+		t.Fatalf("result should be %s. actual: %s", expected, result)
+	}
+}
+
+func TestQueryFields_BelongsTo(t *testing.T) {
+	fields := map[string]interface{}{"user": nil}
+	result := QueryFields(Profile{}, fields)
+	expected := "user_id"
+
+	if result != expected {
+		t.Fatalf("result should be %s. actual: %s", expected, result)
+	}
+}
+
+func TestQueryFields_HasOne(t *testing.T) {
+	fields := map[string]interface{}{"profile": nil}
+	result := QueryFields(User{}, fields)
+	expected := "id"
+
+	if result != expected {
+		t.Fatalf("result should be %s. actual: %s", expected, result)
+	}
+}
+
+func TestQueryFields_HasMany(t *testing.T) {
+	fields := map[string]interface{}{"jobs": nil}
+	result := QueryFields(User{}, fields)
+	expected := "id"
+
+	if result != expected {
+		t.Fatalf("result should be %s. actual: %s", expected, result)
+	}
+}
+
 func TestParseFields_Wildcard(t *testing.T) {
 	fields := "*"
 	result := ParseFields(fields)

--- a/_templates/skeleton/helper/field_test.go.tmpl
+++ b/_templates/skeleton/helper/field_test.go.tmpl
@@ -4,6 +4,87 @@ import (
 	"testing"
 )
 
+type User struct {
+	ID      uint     `json:"id"`
+	Jobs    []*Job   `json:"jobs"`
+	Name    string   `json:"name"`
+	Profile *Profile `json:"profile"`
+}
+
+type Profile struct {
+	ID      uint  `json:"id"`
+	UserID  uint  `json:"user_id"`
+	User    *User `json:"user"`
+	Engaged bool  `json:"engaged"`
+}
+
+type Job struct {
+	ID     uint  `json:"id"`
+	UserID uint  `json:"user_id"`
+	User   *User `json:"user"`
+	RoleCd uint  `json:"role_cd"`
+}
+
+func TestQueryFields_Wildcard(t *testing.T) {
+	fields := map[string]interface{}{"*": nil}
+	result := QueryFields(User{}, fields)
+	expected := "*"
+
+	if result != expected {
+		t.Fatalf("result should be %s. actual: %s", expected, result)
+	}
+}
+
+func TestQueryFields_Primitive(t *testing.T) {
+	fields := map[string]interface{}{"name": nil}
+	result := QueryFields(User{}, fields)
+	expected := "name"
+
+	if result != expected {
+		t.Fatalf("result should be %s. actual: %s", expected, result)
+	}
+}
+
+func TestQueryFields_Multiple(t *testing.T) {
+	fields := map[string]interface{}{"id": nil, "name": nil}
+	result := QueryFields(User{}, fields)
+	expected := "id,name"
+
+	if result != expected {
+		t.Fatalf("result should be %s. actual: %s", expected, result)
+	}
+}
+
+func TestQueryFields_BelongsTo(t *testing.T) {
+	fields := map[string]interface{}{"user": nil}
+	result := QueryFields(Profile{}, fields)
+	expected := "user_id"
+
+	if result != expected {
+		t.Fatalf("result should be %s. actual: %s", expected, result)
+	}
+}
+
+func TestQueryFields_HasOne(t *testing.T) {
+	fields := map[string]interface{}{"profile": nil}
+	result := QueryFields(User{}, fields)
+	expected := "id"
+
+	if result != expected {
+		t.Fatalf("result should be %s. actual: %s", expected, result)
+	}
+}
+
+func TestQueryFields_HasMany(t *testing.T) {
+	fields := map[string]interface{}{"jobs": nil}
+	result := QueryFields(User{}, fields)
+	expected := "id"
+
+	if result != expected {
+		t.Fatalf("result should be %s. actual: %s", expected, result)
+	}
+}
+
 func TestParseFields_Wildcard(t *testing.T) {
 	fields := "*"
 	result := ParseFields(fields)


### PR DESCRIPTION
## WHY
Generated API server can specify fields to fetch by `fields` query parameter. However, in reality, SQL query still tries to fetch ALL fields.

Regardless of `fields` query parameter, the SQL query below is always executed.

```sql
SELECT * FROM tables ...
```

This means that DB performance haven't been improved yet.

## WHAT
Narrow fields dynamically along with `fields` query parameter.

For example...

| `?fields=` | SQL query |
|---|---|
| none | `SELECT *` |
| `fields=id` | `SELECT id` |
| `fields=id,name` | `SELECT id,name` |
| (belongs-to) `fields=user.name` | `SELECT user_id` |
| (has-one) `fields=profile.engaged` | `SELECT id` |
| (has-many) `fields=emails.address` | `SELECT id` |

Non-exist fields are omitted.