### PR TITLE
Extract API namespace from router at gen command

### DIFF
--- a/apig/generate.go
+++ b/apig/generate.go
@@ -433,12 +433,19 @@ func Generate(outDir, modelDir, targetFile string, all bool) int {
 		return 1
 	}
 
+	namespace, err := parseNamespace(filepath.Join(outDir, "router", "router.go"))
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return 1
+	}
+
 	detail := &Detail{
 		Models:    models,
 		ImportDir: importDir[0],
 		VCS:       vcs,
 		User:      user,
 		Project:   project,
+		Namespace: namespace,
 	}
 	if all {
 		if err := generateSkeleton(detail, outDir); err != nil {

--- a/apig/parse_test.go
+++ b/apig/parse_test.go
@@ -22,7 +22,7 @@ func fieldEquals(f1, f2 *Field) bool {
 }
 
 func TestParseModel(t *testing.T) {
-	path := filepath.Join("testdata", "models.go")
+	path := filepath.Join("testdata", "parse", "models.go")
 
 	models, err := parseModel(path)
 
@@ -71,7 +71,7 @@ func TestParseModel(t *testing.T) {
 }
 
 func TestParseImport(t *testing.T) {
-	path := filepath.Join("testdata", "router", "router.go")
+	path := filepath.Join("testdata", "parse", "router.go")
 
 	importPaths, err := parseImport(path)
 
@@ -87,5 +87,20 @@ func TestParseImport(t *testing.T) {
 	expect := "github.com/wantedly/api-server/controllers"
 	if importPath != expect {
 		t.Fatalf("Incorrect import path. expected: %s, actual: %s", expect, importPath)
+	}
+}
+
+func TestParseNamespace(t *testing.T) {
+	path := filepath.Join("testdata", "parse", "router.go")
+
+	namespace, err := parseNamespace(path)
+	if err != nil {
+		t.Fatalf("Failed to parse router. error: %s", err)
+	}
+
+	expected := "api"
+
+	if namespace != expected {
+		t.Fatalf("Incorrect namespace. expected: %s, actual: %s", expected, namespace)
 	}
 }

--- a/apig/testdata/parse/models.go
+++ b/apig/testdata/parse/models.go
@@ -1,0 +1,20 @@
+package model
+
+import (
+	"time"
+)
+
+type User struct {
+	ID        uint       `gorm:"primary_key;AUTO_INCREMENT" json:"id,omitempty"`
+	Name      string     `json:"name,omitempty"`
+	CreatedAt *time.Time `json:"created_at,omitempty"`
+	UpdatedAt *time.Time `json:"updated_at,omitempty"`
+}
+
+type Job struct {
+	ID          uint       `gorm:"primary_key;AUTO_INCREMENT" json:"id,omitempty"`
+	Name        string     `json:"name,omitempty"`
+	Description string     `json:"description,omitempty"`
+	CreatedAt   *time.Time `json:"created_at,omitempty"`
+	UpdatedAt   *time.Time `json:"updated_at,omitempty"`
+}

--- a/apig/testdata/parse/router.go
+++ b/apig/testdata/parse/router.go
@@ -1,0 +1,20 @@
+package router
+
+import (
+	"github.com/wantedly/api-server/controllers"
+
+	"github.com/gin-gonic/gin"
+)
+
+func Initialize(r *gin.Engine) {
+	api := r.Group("api")
+	{
+
+		api.GET("/users", controllers.GetUsers)
+		api.GET("/users/:id", controllers.GetUser)
+		api.POST("/users", controllers.CreateUser)
+		api.PUT("/users/:id", controllers.UpdateUser)
+		api.DELETE("/users/:id", controllers.DeleteUser)
+
+	}
+}


### PR DESCRIPTION
## WHY
When user executes `apig gen --all` at application repository, API namespace always rewrite as `""` (empty string).

## WHAT
Extract namespace from existing `router/router.go` and rewrite with it.

This is another and better approach of #53 .