### PR TITLE
Unbind -v from VCS option

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,11 +28,11 @@ $ make install
 First, creating by `apig new` command.
 
 ```
-$ apig new -u wantedly -v github.com apig-sample
+$ apig new -u wantedly apig-sample
 ```
 
 generates Golang API server boilerplate under `$GOPATH/src/gihhub.com/wantedly/apig-sample`.
-You can omit `-u` and `-v` options. The default of `-u` is github username, and `-v` is `github.com`
+You can omit `-u, --user` and `--vcs` options. The default of `-u, -user` is github username, and `--vcs` is `github.com`
 
 ### 2. Write model code
 

--- a/command/gen.go
+++ b/command/gen.go
@@ -60,7 +60,7 @@ func (c *GenCommand) Synopsis() string {
 
 func (c *GenCommand) Help() string {
 	helpText := `
-Usage: apig gen
+Usage: apig [options] gen
 
   Generates controllers and more based on models
 

--- a/command/new.go
+++ b/command/new.go
@@ -40,7 +40,6 @@ func (c *NewCommand) Run(args []string) int {
 func (c *NewCommand) parseArgs(args []string) error {
 	flag := flag.NewFlagSet("apig", flag.ContinueOnError)
 
-	flag.StringVar(&c.vcs, "v", defaultVCS, "VCS")
 	flag.StringVar(&c.vcs, "vcs", defaultVCS, "VCS")
 	flag.StringVar(&c.username, "u", "", "Username")
 	flag.StringVar(&c.username, "user", "", "Username")
@@ -83,7 +82,7 @@ Usage: apig new PROJECTNAME
   Generate go project and its boilerplate
 
 Options:
-  -vcs=name, -v     Version controll system to use (default: github.com)
+  -vcs=name         Version controll system to use (default: github.com)
   -user=name, -u    Username of VCS (default: username of github in .gitconfig)
 
 `

--- a/command/new.go
+++ b/command/new.go
@@ -77,7 +77,7 @@ func (c *NewCommand) Synopsis() string {
 
 func (c *NewCommand) Help() string {
 	helpText := `
-Usage: apig new PROJECTNAME
+Usage: apig new [options] PROJECTNAME
 
   Generate go project and its boilerplate
 

--- a/command/new.go
+++ b/command/new.go
@@ -82,8 +82,9 @@ Usage: apig new PROJECTNAME
   Generate go project and its boilerplate
 
 Options:
-  -vcs=name         Version controll system to use (default: github.com)
-  -user=name, -u    Username of VCS (default: username of github in .gitconfig)
+  -namespace=namepace, -n    Namespace of API (default: "" (blank string))
+  -user=name, -u             Username of VCS (default: username of github in .gitconfig)
+  -vcs=name                  Version controll system to use (default: github.com)
 
 `
 	return strings.TrimSpace(helpText)


### PR DESCRIPTION
Close #61 

## WHY
`-v` option is now used for showing CLI version.

## WHAT
Unbind `-v` from VCS option and use `--vcs` only.