### PR TITLE
Consider omitempty option

### DIFF
--- a/_example/helper/field.go
+++ b/_example/helper/field.go
@@ -118,19 +118,30 @@ func FieldToMap(model interface{}, fields map[string]interface{}) map[string]int
 	u := make(map[string]interface{})
 	ts, vs := reflect.TypeOf(model), reflect.ValueOf(model)
 
+	var jsonKey string
+	var omitEmpty bool
+
 	for i := 0; i < ts.NumField(); i++ {
-		var jsonKey string
 		field := ts.Field(i)
 		jsonTag := field.Tag.Get("json")
+		omitEmpty = false
 
 		if jsonTag == "" {
 			jsonKey = field.Name
 		} else {
-			jsonKey = strings.Split(jsonTag, ",")[0]
+			ss := strings.Split(jsonTag, ",")
+			jsonKey = ss[0]
+
+			if len(ss) > 1 && ss[1] == "omitempty" {
+				omitEmpty = true
+			}
 		}
 
 		if contains(fields, "*") {
-			u[jsonKey] = vs.Field(i).Interface()
+			if !omitEmpty || !vs.Field(i).IsNil() {
+				u[jsonKey] = vs.Field(i).Interface()
+			}
+
 			continue
 		}
 

--- a/_example/helper/field_test.go
+++ b/_example/helper/field_test.go
@@ -6,9 +6,9 @@ import (
 
 type User struct {
 	ID      uint     `json:"id"`
-	Jobs    []*Job   `json:"jobs"`
+	Jobs    []*Job   `json:"jobs,omitempty"`
 	Name    string   `json:"name"`
-	Profile *Profile `json:"profile"`
+	Profile *Profile `json:"profile,omitempty"`
 }
 
 type Profile struct {
@@ -250,6 +250,60 @@ func TestFieldToMap_Wildcard(t *testing.T) {
 
 	if result["profile"].(*Profile) == nil {
 		t.Fatalf("profile should not be nil. actual: %#v", result["profile"])
+	}
+}
+
+func TestFieldToMap_OmitEmpty(t *testing.T) {
+	user := User{
+		ID:      1,
+		Jobs:    nil,
+		Name:    "Taro Yamada",
+		Profile: nil,
+	}
+
+	fields := map[string]interface{}{
+		"*": nil,
+	}
+	result := FieldToMap(user, fields)
+
+	for _, key := range []string{"id", "name"} {
+		if _, ok := result[key]; !ok {
+			t.Fatalf("%s should exist. actual: %#v", key, result)
+		}
+	}
+
+	for _, key := range []string{"jobs", "profile"} {
+		if _, ok := result[key]; ok {
+			t.Fatalf("%s should not exist. actual: %#v", key, result)
+		}
+	}
+}
+
+func TestFieldToMap_OmitEmptyWithField(t *testing.T) {
+	user := User{
+		ID:      1,
+		Jobs:    nil,
+		Name:    "Taro Yamada",
+		Profile: nil,
+	}
+
+	fields := map[string]interface{}{
+		"id":   nil,
+		"name": nil,
+		"jobs": nil,
+	}
+	result := FieldToMap(user, fields)
+
+	for _, key := range []string{"id", "name", "jobs"} {
+		if _, ok := result[key]; !ok {
+			t.Fatalf("%s should exist. actual: %#v", key, result)
+		}
+	}
+
+	for _, key := range []string{"profile"} {
+		if _, ok := result[key]; ok {
+			t.Fatalf("%s should not exist. actual: %#v", key, result)
+		}
 	}
 }
 

--- a/_templates/skeleton/helper/field.go.tmpl
+++ b/_templates/skeleton/helper/field.go.tmpl
@@ -118,19 +118,30 @@ func FieldToMap(model interface{}, fields map[string]interface{}) map[string]int
 	u := make(map[string]interface{})
 	ts, vs := reflect.TypeOf(model), reflect.ValueOf(model)
 
+	var jsonKey string
+	var omitEmpty bool
+
 	for i := 0; i < ts.NumField(); i++ {
-		var jsonKey string
 		field := ts.Field(i)
 		jsonTag := field.Tag.Get("json")
+		omitEmpty = false
 
 		if jsonTag == "" {
 			jsonKey = field.Name
 		} else {
-			jsonKey = strings.Split(jsonTag, ",")[0]
+			ss := strings.Split(jsonTag, ",")
+			jsonKey = ss[0]
+
+			if len(ss) > 1 && ss[1] == "omitempty" {
+				omitEmpty = true
+			}
 		}
 
 		if contains(fields, "*") {
-			u[jsonKey] = vs.Field(i).Interface()
+			if !omitEmpty || !vs.Field(i).IsNil() {
+				u[jsonKey] = vs.Field(i).Interface()
+			}
+
 			continue
 		}
 

--- a/_templates/skeleton/helper/field_test.go.tmpl
+++ b/_templates/skeleton/helper/field_test.go.tmpl
@@ -210,3 +210,122 @@ func TestParseFields_Included(t *testing.T) {
 		t.Fatalf("result[profile] should be nil: %#v", result)
 	}
 }
+
+var profile = Profile{
+	ID:      1,
+	UserID:  1,
+	User:    nil,
+	Engaged: true,
+}
+
+var job = Job{
+	ID:     1,
+	UserID: 1,
+	User:   nil,
+	RoleCd: 1,
+}
+
+func TestFieldToMap_Wildcard(t *testing.T) {
+	user := User{
+		ID:      1,
+		Jobs:    []*Job{&job},
+		Name:    "Taro Yamada",
+		Profile: &profile,
+	}
+
+	fields := map[string]interface{}{
+		"*": nil,
+	}
+	result := FieldToMap(user, fields)
+
+	for _, key := range []string{"id", "jobs", "name", "profile"} {
+		if _, ok := result[key]; !ok {
+			t.Fatalf("%s should exist. actual: %#v", key, result)
+		}
+	}
+
+	if result["jobs"].([]*Job) == nil {
+		t.Fatalf("jobs should not be nil. actual: %#v", result["jobs"])
+	}
+
+	if result["profile"].(*Profile) == nil {
+		t.Fatalf("profile should not be nil. actual: %#v", result["profile"])
+	}
+}
+
+
+func TestFieldToMap_SpecifyField(t *testing.T) {
+	user := User{
+		ID:      1,
+		Jobs:    nil,
+		Name:    "Taro Yamada",
+		Profile: nil,
+	}
+
+	fields := map[string]interface{}{
+		"id":   nil,
+		"name": nil,
+	}
+	result := FieldToMap(user, fields)
+
+	for _, key := range []string{"id", "name"} {
+		if _, ok := result[key]; !ok {
+			t.Fatalf("%s should exist. actual: %#v", key, result)
+		}
+	}
+
+	for _, key := range []string{"jobs", "profile"} {
+		if _, ok := result[key]; ok {
+			t.Fatalf("%s should not exist. actual: %#v", key, result)
+		}
+	}
+}
+
+func TestFieldToMap_NestedField(t *testing.T) {
+	user := User{
+		ID:      1,
+		Jobs:    []*Job{&job},
+		Name:    "Taro Yamada",
+		Profile: &profile,
+	}
+
+	fields := map[string]interface{}{
+		"profile": map[string]interface{}{
+			"id": nil,
+		},
+		"name": nil,
+	}
+	result := FieldToMap(user, fields)
+
+	for _, key := range []string{"name", "profile"} {
+		if _, ok := result[key]; !ok {
+			t.Fatalf("%s should exist. actual: %#v", key, result)
+		}
+	}
+
+	for _, key := range []string{"id", "jobs"} {
+		if _, ok := result[key]; ok {
+			t.Fatalf("%s should not exist. actual: %#v", key, result)
+		}
+	}
+
+	if result["profile"].(map[string]interface{}) == nil {
+		t.Fatalf("profile should not be nil. actual: %#v", result)
+	}
+
+	if _, ok := result["profile"].(map[string]interface{})["id"]; !ok {
+		t.Fatalf("profile.id should exist. actual: %#v", result)
+	}
+
+	for _, key := range []string{"id"} {
+		if _, ok := result["profile"].(map[string]interface{})[key]; !ok {
+			t.Fatalf("profile.%s should exist. actual: %#v", key, result)
+		}
+	}
+
+	for _, key := range []string{"user_id", "user", "engaged"} {
+		if _, ok := result["profile"].(map[string]interface{})[key]; ok {
+			t.Fatalf("profile.%s should not exist. actual: %#v", key, result)
+		}
+	}
+}

--- a/_templates/skeleton/helper/field_test.go.tmpl
+++ b/_templates/skeleton/helper/field_test.go.tmpl
@@ -6,9 +6,9 @@ import (
 
 type User struct {
 	ID      uint     `json:"id"`
-	Jobs    []*Job   `json:"jobs"`
+	Jobs    []*Job   `json:"jobs,omitempty"`
 	Name    string   `json:"name"`
-	Profile *Profile `json:"profile"`
+	Profile *Profile `json:"profile,omitempty"`
 }
 
 type Profile struct {
@@ -253,6 +253,59 @@ func TestFieldToMap_Wildcard(t *testing.T) {
 	}
 }
 
+func TestFieldToMap_OmitEmpty(t *testing.T) {
+	user := User{
+		ID:      1,
+		Jobs:    nil,
+		Name:    "Taro Yamada",
+		Profile: nil,
+	}
+
+	fields := map[string]interface{}{
+		"*": nil,
+	}
+	result := FieldToMap(user, fields)
+
+	for _, key := range []string{"id", "name"} {
+		if _, ok := result[key]; !ok {
+			t.Fatalf("%s should exist. actual: %#v", key, result)
+		}
+	}
+
+	for _, key := range []string{"jobs", "profile"} {
+		if _, ok := result[key]; ok {
+			t.Fatalf("%s should not exist. actual: %#v", key, result)
+		}
+	}
+}
+
+func TestFieldToMap_OmitEmptyWithField(t *testing.T) {
+	user := User{
+		ID:      1,
+		Jobs:    nil,
+		Name:    "Taro Yamada",
+		Profile: nil,
+	}
+
+	fields := map[string]interface{}{
+		"id":   nil,
+		"name": nil,
+		"jobs": nil,
+	}
+	result := FieldToMap(user, fields)
+
+	for _, key := range []string{"id", "name", "jobs"} {
+		if _, ok := result[key]; !ok {
+			t.Fatalf("%s should exist. actual: %#v", key, result)
+		}
+	}
+
+	for _, key := range []string{"profile"} {
+		if _, ok := result[key]; ok {
+			t.Fatalf("%s should not exist. actual: %#v", key, result)
+		}
+	}
+}
 
 func TestFieldToMap_SpecifyField(t *testing.T) {
 	user := User{


### PR DESCRIPTION
## WHY
If response data contains null, currently response JSON also contains null.

## WHAT
If `omitempty` tag is specified in field definition, exclude the null field from the response.

This feature is enabled when user tries to fetch all fields (`*`). When some fields are specified in `?fields=` parameter, response JSON contains the fields even if they are null.

Before implementing this feature, I added some test for existing `FieldToMap` method.