### PR TITLE
Update README how to install and build

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ Go 1.5 is acceptable, but `GO15VENDOREXPERIMENT=1` must be set.
 After installing required version of Go, you can build and install `apig` by
 
 ```bash
+$ go get -d -u github.com/wantedly/apig
+$ cd $GOPATH/src/github.com/wantedly/apig
 $ make
 $ make install
 ```

--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ It creates all necessary codes to provide RESTful endpoints of models.
 Finally, just build as normal go code.
 
 ```bash
+$ go get ./...
 $ go build -o bin/server
 ```
 


### PR DESCRIPTION
## WHY
At first, simple `go get github.com/wantedly/apig` fails due to lack of go-bindata. Additionally, we cannot build generated API server from scratch.

## WHAT
Write how to download this repository and how to download dependencies of API server.