### PR TITLE
User field name as JSON key if no tag is provided

### DIFF
--- a/apig/parse.go
+++ b/apig/parse.go
@@ -11,10 +11,8 @@ import (
 )
 
 func parseField(field *ast.Field) (*Field, error) {
-	fieldNames := []string{}
-
-	for _, name := range field.Names {
-		fieldNames = append(fieldNames, name.Name)
+	if len(field.Names) != 1 {
+		return nil, errors.New("Failed to read model files. Please fix struct.")
 	}
 
 	var fieldType string
@@ -59,12 +57,8 @@ func parseField(field *ast.Field) (*Field, error) {
 
 	fieldTag = field.Tag.Value
 
-	if len(fieldNames) != 1 {
-		return nil, errors.New("Failed to read model files. Please fix struct " + fieldNames[0])
-	}
-
 	fs := Field{
-		Name:     fieldNames[0],
+		Name:     field.Names[0].Name,
 		JSONName: jsonName,
 		Type:     fieldType,
 		Tag:      fieldTag,

--- a/apig/parse.go
+++ b/apig/parse.go
@@ -15,8 +15,9 @@ func parseField(field *ast.Field) (*Field, error) {
 		return nil, errors.New("Failed to read model files. Please fix struct.")
 	}
 
+	fieldName := field.Names[0].Name
+
 	var fieldType string
-	var fieldTag string
 
 	switch x := field.Type.(type) {
 	case *ast.Ident: // e.g. string
@@ -47,18 +48,25 @@ func parseField(field *ast.Field) (*Field, error) {
 		}
 	}
 
-	s, err := strconv.Unquote(field.Tag.Value)
+	var jsonName string
+	var fieldTag string
 
-	if err != nil {
-		s = field.Tag.Value
+	if field.Tag == nil {
+		jsonName = fieldName
+		fieldTag = ""
+	} else {
+		s, err := strconv.Unquote(field.Tag.Value)
+
+		if err != nil {
+			s = field.Tag.Value
+		}
+
+		jsonName = strings.Split((reflect.StructTag)(s).Get("json"), ",")[0]
+		fieldTag = field.Tag.Value
 	}
 
-	jsonName := strings.Split((reflect.StructTag)(s).Get("json"), ",")[0]
-
-	fieldTag = field.Tag.Value
-
 	fs := Field{
-		Name:     field.Names[0].Name,
+		Name:     fieldName,
 		JSONName: jsonName,
 		Type:     fieldType,
 		Tag:      fieldTag,

--- a/apig/parse_test.go
+++ b/apig/parse_test.go
@@ -58,7 +58,7 @@ func TestParseModel(t *testing.T) {
 		},
 		&Field{
 			Name:     "UpdatedAt",
-			JSONName: "updated_at",
+			JSONName: "UpdatedAt",
 			Type:     "*time.Time",
 		},
 	}

--- a/apig/testdata/parse/models.go
+++ b/apig/testdata/parse/models.go
@@ -8,7 +8,7 @@ type User struct {
 	ID        uint       `gorm:"primary_key;AUTO_INCREMENT" json:"id,omitempty"`
 	Name      string     `json:"name,omitempty"`
 	CreatedAt *time.Time `json:"created_at,omitempty"`
-	UpdatedAt *time.Time `json:"updated_at,omitempty"`
+	UpdatedAt *time.Time
 }
 
 type Job struct {


### PR DESCRIPTION
Close #71

## WHY
Current apig is based on that all fields are tagged with `json`. So if no tag is provided, `apig new` and `apig gen` fails with panic.

## WHAT
If no tag is provided, use Go-struct field name as JSON key.