### PR TITLE
Write API namespace in README dynamically

### DIFF
--- a/_templates/README.md.tmpl
+++ b/_templates/README.md.tmpl
@@ -3,15 +3,15 @@
 Simple Rest API using gin(framework) & gorm(orm)
 
 ## Endpoint list
-{{ range . }}
+{{ range .Models }}
 ### {{ pluralize .Name }} Resource
 
 ```
-GET    /api/{{ pluralize (tolower .Name) }}
-GET    /api/{{ pluralize (tolower .Name) }}/:id
-POST   /api/{{ pluralize (tolower .Name) }}
-PUT    /api/{{ pluralize (tolower .Name) }}/:id
-DELETE /api/{{ pluralize (tolower .Name) }}/:id
+GET    {{ if ($.Namespace) ne "" }}/{{ $.Namespace }}{{ end }}/{{ pluralize (tolower .Name) }}
+GET    {{ if ($.Namespace) ne "" }}/{{ $.Namespace }}{{ end }}/{{ pluralize (tolower .Name) }}/:id
+POST   {{ if ($.Namespace) ne "" }}/{{ $.Namespace }}{{ end }}/{{ pluralize (tolower .Name) }}
+PUT    {{ if ($.Namespace) ne "" }}/{{ $.Namespace }}{{ end }}/{{ pluralize (tolower .Name) }}/:id
+DELETE {{ if ($.Namespace) ne "" }}/{{ $.Namespace }}{{ end }}/{{ pluralize (tolower .Name) }}/:id
 ```
 {{ end }}
 server runs at http://localhost:8080

--- a/apig/generate.go
+++ b/apig/generate.go
@@ -208,7 +208,7 @@ func generateController(detail *Detail, outDir string) error {
 	return nil
 }
 
-func generateREADME(models []*Model, outDir string) error {
+func generateREADME(detail *Detail, outDir string) error {
 	body, err := Asset(filepath.Join(templateDir, "README.md.tmpl"))
 
 	if err != nil {
@@ -223,7 +223,7 @@ func generateREADME(models []*Model, outDir string) error {
 
 	var buf bytes.Buffer
 
-	if err := tmpl.Execute(&buf, models); err != nil {
+	if err := tmpl.Execute(&buf, detail); err != nil {
 		return err
 	}
 
@@ -473,7 +473,7 @@ func Generate(outDir, modelDir, targetFile string, all bool) int {
 		fmt.Fprintln(os.Stderr, err)
 		return 1
 	}
-	if err := generateREADME(models, outDir); err != nil {
+	if err := generateREADME(detail, outDir); err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		return 1
 	}

--- a/apig/generate_test.go
+++ b/apig/generate_test.go
@@ -49,6 +49,7 @@ var detail = &Detail{
 	Model:     userModel,
 	Models:    []*Model{userModel},
 	ImportDir: "github.com/wantedly/api-server",
+	Namespace: "",
 }
 
 func compareFiles(f1, f2 string) bool {
@@ -143,7 +144,7 @@ func TestGenerateREADME(t *testing.T) {
 	}
 	defer os.RemoveAll(outDir)
 
-	if err := generateREADME([]*Model{userModel}, outDir); err != nil {
+	if err := generateREADME(detail, outDir); err != nil {
 		t.Fatalf("Error should not be raised: %s", err)
 	}
 

--- a/apig/testdata/README.md
+++ b/apig/testdata/README.md
@@ -7,11 +7,11 @@ Simple Rest API using gin(framework) & gorm(orm)
 ### Users Resource
 
 ```
-GET    /api/users
-GET    /api/users/:id
-POST   /api/users
-PUT    /api/users/:id
-DELETE /api/users/:id
+GET    /users
+GET    /users/:id
+POST   /users
+PUT    /users/:id
+DELETE /users/:id
 ```
 
 server runs at http://localhost:8080


### PR DESCRIPTION
## WHY
Now API namespace can be changed by user.

## WHAT
Change API namespace in README dynamically.