### PR TITLE
Return the list of endpoints from top page

### DIFF
--- a/_example/controllers/root.go
+++ b/_example/controllers/root.go
@@ -7,7 +7,7 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
-func APIIndex(c *gin.Context) {
+func APIEndpoints(c *gin.Context) {
 	reqScheme := c.Request.URL.Scheme
 	reqHost := c.Request.Host
 	baseURL := fmt.Sprintf("%s://%s", reqScheme, reqHost)

--- a/_example/controllers/root.go
+++ b/_example/controllers/root.go
@@ -1,0 +1,29 @@
+package controllers
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+)
+
+func APIIndex(c *gin.Context) {
+	reqScheme := c.Request.URL.Scheme
+	reqHost := c.Request.Host
+	baseURL := fmt.Sprintf("%s://%s", reqScheme, reqHost)
+
+	resources := map[string]string{
+		"companies_url": baseURL + "/companies",
+		"company_url":   baseURL + "/companies/{id}",
+		"emails_url":    baseURL + "/emails",
+		"email_url":     baseURL + "/emails/{id}",
+		"jobs_url":      baseURL + "/jobs",
+		"job_url":       baseURL + "/jobs/{id}",
+		"profiles_url":  baseURL + "/profiles",
+		"profile_url":   baseURL + "/profiles/{id}",
+		"users_url":     baseURL + "/users",
+		"user_url":      baseURL + "/users/{id}",
+	}
+
+	c.IndentedJSON(http.StatusOK, resources)
+}

--- a/_example/router/router.go
+++ b/_example/router/router.go
@@ -7,6 +7,8 @@ import (
 )
 
 func Initialize(r *gin.Engine) {
+	r.GET("/", controllers.APIEndpoints)
+
 	api := r.Group("api")
 	{
 

--- a/_templates/root_controller.go.tmpl
+++ b/_templates/root_controller.go.tmpl
@@ -1,0 +1,21 @@
+package controllers
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+)
+
+func APIEndpoints(c *gin.Context) {
+	reqScheme := c.Request.URL.Scheme
+	reqHost := c.Request.Host
+	baseURL := fmt.Sprintf("%s://%s", reqScheme, reqHost)
+
+	resources := map[string]string{
+{{ range .Models }}		"{{ pluralize (tolower .Name) }}_url": baseURL + "{{ if ($.Namespace) ne "" }}/{{ $.Namespace }}{{ end }}/{{ pluralize (tolower .Name) }}",
+		"{{ tolower .Name }}_url":  baseURL + "{{ if ($.Namespace) ne "" }}/{{ $.Namespace }}{{ end }}/{{ pluralize (tolower .Name) }}/{id}",
+{{ end }}	}
+
+	c.IndentedJSON(http.StatusOK, resources)
+}

--- a/_templates/router.go.tmpl
+++ b/_templates/router.go.tmpl
@@ -7,6 +7,8 @@ import (
 )
 
 func Initialize(r *gin.Engine) {
+	r.GET("/", controllers.APIEndpoints)
+
 	api := r.Group("{{ .Namespace }}")
 	{
 {{ range .Models }}

--- a/apig/generate.go
+++ b/apig/generate.go
@@ -208,6 +208,42 @@ func generateController(detail *Detail, outDir string) error {
 	return nil
 }
 
+func generateRootController(detail *Detail, outDir string) error {
+	body, err := Asset(filepath.Join(templateDir, "root_controller.go.tmpl"))
+
+	if err != nil {
+		return err
+	}
+
+	tmpl, err := template.New("root_controller").Funcs(funcMap).Parse(string(body))
+
+	if err != nil {
+		return err
+	}
+
+	var buf bytes.Buffer
+
+	if err := tmpl.Execute(&buf, detail); err != nil {
+		return err
+	}
+
+	dstPath := filepath.Join(outDir, "controllers", "root.go")
+
+	if !util.FileExists(filepath.Dir(dstPath)) {
+		if err := util.Mkdir(filepath.Dir(dstPath)); err != nil {
+			return err
+		}
+	}
+
+	if err := ioutil.WriteFile(dstPath, buf.Bytes(), 0644); err != nil {
+		return err
+	}
+
+	fmt.Printf("\t\x1b[32m%s\x1b[0m %s\n", "create", dstPath)
+
+	return nil
+}
+
 func generateREADME(detail *Detail, outDir string) error {
 	body, err := Asset(filepath.Join(templateDir, "README.md.tmpl"))
 

--- a/apig/generate_test.go
+++ b/apig/generate_test.go
@@ -137,6 +137,32 @@ func TestGenerateController(t *testing.T) {
 	}
 }
 
+func TestGenerateRootController(t *testing.T) {
+	outDir, err := ioutil.TempDir("", "generateRootController")
+	if err != nil {
+		t.Fatal("Failed to create tempdir")
+	}
+	defer os.RemoveAll(outDir)
+
+	if err := generateRootController(detail, outDir); err != nil {
+		t.Fatalf("Error should not be raised: %s", err)
+	}
+
+	path := filepath.Join(outDir, "controllers", "root.go")
+	_, err = os.Stat(path)
+	if err != nil {
+		t.Fatalf("Controller file is not generated: %s", path)
+	}
+
+	fixture := filepath.Join("testdata", "controllers", "root.go")
+
+	if !compareFiles(path, fixture) {
+		c1, _ := ioutil.ReadFile(fixture)
+		c2, _ := ioutil.ReadFile(path)
+		t.Fatalf("Failed to generate controller correctly.\nexpected:\n%s\nactual:\n%s", string(c1), string(c2))
+	}
+}
+
 func TestGenerateREADME(t *testing.T) {
 	outDir, err := ioutil.TempDir("", "generateREADME")
 	if err != nil {

--- a/apig/testdata/controllers/root.go
+++ b/apig/testdata/controllers/root.go
@@ -1,0 +1,21 @@
+package controllers
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+)
+
+func APIEndpoints(c *gin.Context) {
+	reqScheme := c.Request.URL.Scheme
+	reqHost := c.Request.Host
+	baseURL := fmt.Sprintf("%s://%s", reqScheme, reqHost)
+
+	resources := map[string]string{
+		"users_url": baseURL + "/users",
+		"user_url":  baseURL + "/users/{id}",
+	}
+
+	c.IndentedJSON(http.StatusOK, resources)
+}

--- a/apig/testdata/parse/router.go
+++ b/apig/testdata/parse/router.go
@@ -7,6 +7,8 @@ import (
 )
 
 func Initialize(r *gin.Engine) {
+	r.GET("/", controllers.APIEndpoints)
+
 	api := r.Group("api")
 	{
 

--- a/apig/testdata/router/router.go
+++ b/apig/testdata/router/router.go
@@ -7,6 +7,8 @@ import (
 )
 
 func Initialize(r *gin.Engine) {
+	r.GET("/", controllers.APIEndpoints)
+
 	api := r.Group("")
 	{
 


### PR DESCRIPTION
Close #64 

## WHY
Currently, root endpoint 'http://example.com/' return empty and `404 Not Found`. This behavior is not so good especially for newcomers.

## WHAT
Like https://api.github.com/ , let API server return all available API endpoints.

Here is example:

```bash
$ curl localhost:8080
{
    "companies_url": "://localhost:8080/companies",
    "company_url": "://localhost:8080/companies/{id}",
    "email_url": "://localhost:8080/emails/{id}",
    "emails_url": "://localhost:8080/emails",
    "job_url": "://localhost:8080/jobs/{id}",
    "jobs_url": "://localhost:8080/jobs",
    "profile_url": "://localhost:8080/profiles/{id}",
    "profiles_url": "://localhost:8080/profiles",
    "user_url": "://localhost:8080/users/{id}",
    "users_url": "://localhost:8080/users"
}
```