### PR TITLE
Narrow fields to retrive again

### DIFF
--- a/_example/controllers/company.go
+++ b/_example/controllers/company.go
@@ -19,9 +19,10 @@ func GetCompanies(c *gin.Context) {
 		return
 	}
 
+	ids := c.DefaultQuery("ids", "")
 	preloads := c.DefaultQuery("preloads", "")
 	fields := helper.ParseFields(c.DefaultQuery("fields", "*"))
-	ids := c.DefaultQuery("ids", "")
+	queryFields := helper.QueryFields(models.Company{}, fields)
 
 	pagination := dbpkg.Pagination{}
 	db, err := pagination.Paginate(c)
@@ -38,7 +39,7 @@ func GetCompanies(c *gin.Context) {
 	}
 
 	var companies []models.Company
-	if err := db.Select("*").Find(&companies).Error; err != nil {
+	if err := db.Select(queryFields).Find(&companies).Error; err != nil {
 		c.JSON(400, gin.H{"error": err.Error()})
 		return
 	}
@@ -80,12 +81,13 @@ func GetCompany(c *gin.Context) {
 	id := c.Params.ByName("id")
 	preloads := c.DefaultQuery("preloads", "")
 	fields := helper.ParseFields(c.DefaultQuery("fields", "*"))
+	queryFields := helper.QueryFields(models.Company{}, fields)
 
 	db := dbpkg.DBInstance(c)
 	db = dbpkg.SetPreloads(preloads, db)
 
 	var company models.Company
-	if err := db.Select("*").First(&company, id).Error; err != nil {
+	if err := db.Select(queryFields).First(&company, id).Error; err != nil {
 		content := gin.H{"error": "company with id#" + id + " not found"}
 		c.JSON(404, content)
 		return

--- a/_example/controllers/email.go
+++ b/_example/controllers/email.go
@@ -19,9 +19,10 @@ func GetEmails(c *gin.Context) {
 		return
 	}
 
+	ids := c.DefaultQuery("ids", "")
 	preloads := c.DefaultQuery("preloads", "")
 	fields := helper.ParseFields(c.DefaultQuery("fields", "*"))
-	ids := c.DefaultQuery("ids", "")
+	queryFields := helper.QueryFields(models.Email{}, fields)
 
 	pagination := dbpkg.Pagination{}
 	db, err := pagination.Paginate(c)
@@ -38,7 +39,7 @@ func GetEmails(c *gin.Context) {
 	}
 
 	var emails []models.Email
-	if err := db.Select("*").Find(&emails).Error; err != nil {
+	if err := db.Select(queryFields).Find(&emails).Error; err != nil {
 		c.JSON(400, gin.H{"error": err.Error()})
 		return
 	}
@@ -80,12 +81,13 @@ func GetEmail(c *gin.Context) {
 	id := c.Params.ByName("id")
 	preloads := c.DefaultQuery("preloads", "")
 	fields := helper.ParseFields(c.DefaultQuery("fields", "*"))
+	queryFields := helper.QueryFields(models.Email{}, fields)
 
 	db := dbpkg.DBInstance(c)
 	db = dbpkg.SetPreloads(preloads, db)
 
 	var email models.Email
-	if err := db.Select("*").First(&email, id).Error; err != nil {
+	if err := db.Select(queryFields).First(&email, id).Error; err != nil {
 		content := gin.H{"error": "email with id#" + id + " not found"}
 		c.JSON(404, content)
 		return

--- a/_example/controllers/job.go
+++ b/_example/controllers/job.go
@@ -19,9 +19,10 @@ func GetJobs(c *gin.Context) {
 		return
 	}
 
+	ids := c.DefaultQuery("ids", "")
 	preloads := c.DefaultQuery("preloads", "")
 	fields := helper.ParseFields(c.DefaultQuery("fields", "*"))
-	ids := c.DefaultQuery("ids", "")
+	queryFields := helper.QueryFields(models.Job{}, fields)
 
 	pagination := dbpkg.Pagination{}
 	db, err := pagination.Paginate(c)
@@ -38,7 +39,7 @@ func GetJobs(c *gin.Context) {
 	}
 
 	var jobs []models.Job
-	if err := db.Select("*").Find(&jobs).Error; err != nil {
+	if err := db.Select(queryFields).Find(&jobs).Error; err != nil {
 		c.JSON(400, gin.H{"error": err.Error()})
 		return
 	}
@@ -80,12 +81,13 @@ func GetJob(c *gin.Context) {
 	id := c.Params.ByName("id")
 	preloads := c.DefaultQuery("preloads", "")
 	fields := helper.ParseFields(c.DefaultQuery("fields", "*"))
+	queryFields := helper.QueryFields(models.Job{}, fields)
 
 	db := dbpkg.DBInstance(c)
 	db = dbpkg.SetPreloads(preloads, db)
 
 	var job models.Job
-	if err := db.Select("*").First(&job, id).Error; err != nil {
+	if err := db.Select(queryFields).First(&job, id).Error; err != nil {
 		content := gin.H{"error": "job with id#" + id + " not found"}
 		c.JSON(404, content)
 		return

--- a/_example/controllers/profile.go
+++ b/_example/controllers/profile.go
@@ -19,9 +19,10 @@ func GetProfiles(c *gin.Context) {
 		return
 	}
 
+	ids := c.DefaultQuery("ids", "")
 	preloads := c.DefaultQuery("preloads", "")
 	fields := helper.ParseFields(c.DefaultQuery("fields", "*"))
-	ids := c.DefaultQuery("ids", "")
+	queryFields := helper.QueryFields(models.Profile{}, fields)
 
 	pagination := dbpkg.Pagination{}
 	db, err := pagination.Paginate(c)
@@ -38,7 +39,7 @@ func GetProfiles(c *gin.Context) {
 	}
 
 	var profiles []models.Profile
-	if err := db.Select("*").Find(&profiles).Error; err != nil {
+	if err := db.Select(queryFields).Find(&profiles).Error; err != nil {
 		c.JSON(400, gin.H{"error": err.Error()})
 		return
 	}
@@ -80,12 +81,13 @@ func GetProfile(c *gin.Context) {
 	id := c.Params.ByName("id")
 	preloads := c.DefaultQuery("preloads", "")
 	fields := helper.ParseFields(c.DefaultQuery("fields", "*"))
+	queryFields := helper.QueryFields(models.Profile{}, fields)
 
 	db := dbpkg.DBInstance(c)
 	db = dbpkg.SetPreloads(preloads, db)
 
 	var profile models.Profile
-	if err := db.Select("*").First(&profile, id).Error; err != nil {
+	if err := db.Select(queryFields).First(&profile, id).Error; err != nil {
 		content := gin.H{"error": "profile with id#" + id + " not found"}
 		c.JSON(404, content)
 		return

--- a/_example/controllers/user.go
+++ b/_example/controllers/user.go
@@ -19,9 +19,10 @@ func GetUsers(c *gin.Context) {
 		return
 	}
 
+	ids := c.DefaultQuery("ids", "")
 	preloads := c.DefaultQuery("preloads", "")
 	fields := helper.ParseFields(c.DefaultQuery("fields", "*"))
-	ids := c.DefaultQuery("ids", "")
+	queryFields := helper.QueryFields(models.User{}, fields)
 
 	pagination := dbpkg.Pagination{}
 	db, err := pagination.Paginate(c)
@@ -38,7 +39,7 @@ func GetUsers(c *gin.Context) {
 	}
 
 	var users []models.User
-	if err := db.Select("*").Find(&users).Error; err != nil {
+	if err := db.Select(queryFields).Find(&users).Error; err != nil {
 		c.JSON(400, gin.H{"error": err.Error()})
 		return
 	}
@@ -80,12 +81,13 @@ func GetUser(c *gin.Context) {
 	id := c.Params.ByName("id")
 	preloads := c.DefaultQuery("preloads", "")
 	fields := helper.ParseFields(c.DefaultQuery("fields", "*"))
+	queryFields := helper.QueryFields(models.User{}, fields)
 
 	db := dbpkg.DBInstance(c)
 	db = dbpkg.SetPreloads(preloads, db)
 
 	var user models.User
-	if err := db.Select("*").First(&user, id).Error; err != nil {
+	if err := db.Select(queryFields).First(&user, id).Error; err != nil {
 		content := gin.H{"error": "user with id#" + id + " not found"}
 		c.JSON(404, content)
 		return

--- a/_templates/controller.go.tmpl
+++ b/_templates/controller.go.tmpl
@@ -19,9 +19,10 @@ func Get{{ pluralize .Model.Name }}(c *gin.Context) {
 		return
 	}
 
+	ids := c.DefaultQuery("ids", "")
 	preloads := c.DefaultQuery("preloads", "")
 	fields := helper.ParseFields(c.DefaultQuery("fields", "*"))
-	ids := c.DefaultQuery("ids", "")
+	queryFields := helper.QueryFields(models.{{ .Model.Name }}{}, fields)
 
 	pagination := dbpkg.Pagination{}
 	db, err := pagination.Paginate(c)
@@ -38,7 +39,7 @@ func Get{{ pluralize .Model.Name }}(c *gin.Context) {
 	}
 
 	var {{ pluralize (tolower .Model.Name) }} []models.{{ .Model.Name }}
-	if err := db.Select("*").Find(&{{ pluralize (tolower .Model.Name) }}).Error; err != nil {
+	if err := db.Select(queryFields).Find(&{{ pluralize (tolower .Model.Name) }}).Error; err != nil {
 		c.JSON(400, gin.H{"error": err.Error()})
 		return
 	}
@@ -80,12 +81,13 @@ func Get{{ .Model.Name }}(c *gin.Context) {
 	id := c.Params.ByName("id")
 	preloads := c.DefaultQuery("preloads", "")
 	fields := helper.ParseFields(c.DefaultQuery("fields", "*"))
+	queryFields := helper.QueryFields(models.{{ .Model.Name }}{}, fields)
 
 	db := dbpkg.DBInstance(c)
 	db = dbpkg.SetPreloads(preloads, db)
 
 	var {{ tolower .Model.Name }} models.{{ .Model.Name }}
-	if err := db.Select("*").First(&{{ tolower .Model.Name }}, id).Error; err != nil {
+	if err := db.Select(queryFields).First(&{{ tolower .Model.Name }}, id).Error; err != nil {
 		content := gin.H{"error": "{{ tolower .Model.Name }} with id#" + id + " not found"}
 		c.JSON(404, content)
 		return

--- a/apig/testdata/controllers/user.go
+++ b/apig/testdata/controllers/user.go
@@ -19,9 +19,10 @@ func GetUsers(c *gin.Context) {
 		return
 	}
 
+	ids := c.DefaultQuery("ids", "")
 	preloads := c.DefaultQuery("preloads", "")
 	fields := helper.ParseFields(c.DefaultQuery("fields", "*"))
-	ids := c.DefaultQuery("ids", "")
+	queryFields := helper.QueryFields(models.User{}, fields)
 
 	pagination := dbpkg.Pagination{}
 	db, err := pagination.Paginate(c)
@@ -38,7 +39,7 @@ func GetUsers(c *gin.Context) {
 	}
 
 	var users []models.User
-	if err := db.Select("*").Find(&users).Error; err != nil {
+	if err := db.Select(queryFields).Find(&users).Error; err != nil {
 		c.JSON(400, gin.H{"error": err.Error()})
 		return
 	}
@@ -80,12 +81,13 @@ func GetUser(c *gin.Context) {
 	id := c.Params.ByName("id")
 	preloads := c.DefaultQuery("preloads", "")
 	fields := helper.ParseFields(c.DefaultQuery("fields", "*"))
+	queryFields := helper.QueryFields(models.User{}, fields)
 
 	db := dbpkg.DBInstance(c)
 	db = dbpkg.SetPreloads(preloads, db)
 
 	var user models.User
-	if err := db.Select("*").First(&user, id).Error; err != nil {
+	if err := db.Select(queryFields).First(&user, id).Error; err != nil {
 		content := gin.H{"error": "user with id#" + id + " not found"}
 		c.JSON(404, content)
 		return


### PR DESCRIPTION
## WHY
Few weeks ago, I introduced the feature to narrow fields in SQL query (https://github.com/wantedly/apig/pull/57). However, I missed to update controller template at the time. At #56 I overwrote all example files with code which omitted the feature, so now this feature is NOT enabled in generated API server.

## WHAT
Update controller template to narrow fields rightly and re-introduce this feature.