### PR TITLE
Generate root controller

### DIFF
--- a/_example/controllers/root.go
+++ b/_example/controllers/root.go
@@ -20,16 +20,16 @@ func APIEndpoints(c *gin.Context) {
 	baseURL := fmt.Sprintf("%s://%s", reqScheme, reqHost)
 
 	resources := map[string]string{
-		"companies_url": baseURL + "/companies",
-		"company_url":   baseURL + "/companies/{id}",
-		"emails_url":    baseURL + "/emails",
-		"email_url":     baseURL + "/emails/{id}",
-		"jobs_url":      baseURL + "/jobs",
-		"job_url":       baseURL + "/jobs/{id}",
-		"profiles_url":  baseURL + "/profiles",
-		"profile_url":   baseURL + "/profiles/{id}",
-		"users_url":     baseURL + "/users",
-		"user_url":      baseURL + "/users/{id}",
+		"companies_url": baseURL + "/api/companies",
+		"company_url":   baseURL + "/api/companies/{id}",
+		"emails_url":    baseURL + "/api/emails",
+		"email_url":     baseURL + "/api/emails/{id}",
+		"jobs_url":      baseURL + "/api/jobs",
+		"job_url":       baseURL + "/api/jobs/{id}",
+		"profiles_url":  baseURL + "/api/profiles",
+		"profile_url":   baseURL + "/api/profiles/{id}",
+		"users_url":     baseURL + "/api/users",
+		"user_url":      baseURL + "/api/users/{id}",
 	}
 
 	c.IndentedJSON(http.StatusOK, resources)

--- a/_example/controllers/root.go
+++ b/_example/controllers/root.go
@@ -8,7 +8,12 @@ import (
 )
 
 func APIEndpoints(c *gin.Context) {
-	reqScheme := c.Request.URL.Scheme
+	var reqScheme string
+	if c.Request.TLS != nil {
+		reqScheme = "https"
+	} else {
+		reqScheme = "http"
+	}
 	reqHost := c.Request.Host
 	baseURL := fmt.Sprintf("%s://%s", reqScheme, reqHost)
 

--- a/_example/controllers/root.go
+++ b/_example/controllers/root.go
@@ -9,11 +9,13 @@ import (
 
 func APIEndpoints(c *gin.Context) {
 	var reqScheme string
+
 	if c.Request.TLS != nil {
 		reqScheme = "https"
 	} else {
 		reqScheme = "http"
 	}
+
 	reqHost := c.Request.Host
 	baseURL := fmt.Sprintf("%s://%s", reqScheme, reqHost)
 

--- a/_templates/root_controller.go.tmpl
+++ b/_templates/root_controller.go.tmpl
@@ -8,7 +8,12 @@ import (
 )
 
 func APIEndpoints(c *gin.Context) {
-	reqScheme := c.Request.URL.Scheme
+	var reqScheme string
+	if c.Request.TLS != nil {
+		reqScheme = "https"
+	} else {
+		reqScheme = "http"
+	}
 	reqHost := c.Request.Host
 	baseURL := fmt.Sprintf("%s://%s", reqScheme, reqHost)
 

--- a/_templates/root_controller.go.tmpl
+++ b/_templates/root_controller.go.tmpl
@@ -18,8 +18,8 @@ func APIEndpoints(c *gin.Context) {
 	baseURL := fmt.Sprintf("%s://%s", reqScheme, reqHost)
 
 	resources := map[string]string{
-{{ range .Models }}		"{{ pluralize (tolower .Name) }}_url": baseURL + "{{ if ($.Namespace) ne "" }}/{{ $.Namespace }}{{ end }}/{{ pluralize (tolower .Name) }}",
-		"{{ tolower .Name }}_url":  baseURL + "{{ if ($.Namespace) ne "" }}/{{ $.Namespace }}{{ end }}/{{ pluralize (tolower .Name) }}/{id}",
+{{ range .Models }}		"{{ pluralize (toSnakeCase .Name) }}_url": baseURL + "{{ if ($.Namespace) ne "" }}/{{ $.Namespace }}{{ end }}/{{ pluralize (toSnakeCase .Name) }}",
+		"{{ toSnakeCase .Name }}_url":  baseURL + "{{ if ($.Namespace) ne "" }}/{{ $.Namespace }}{{ end }}/{{ pluralize (toSnakeCase .Name) }}/{id}",
 {{ end }}	}
 
 	c.IndentedJSON(http.StatusOK, resources)

--- a/_templates/root_controller.go.tmpl
+++ b/_templates/root_controller.go.tmpl
@@ -9,11 +9,13 @@ import (
 
 func APIEndpoints(c *gin.Context) {
 	var reqScheme string
+
 	if c.Request.TLS != nil {
 		reqScheme = "https"
 	} else {
 		reqScheme = "http"
 	}
+
 	reqHost := c.Request.Host
 	baseURL := fmt.Sprintf("%s://%s", reqScheme, reqHost)
 

--- a/apig/generate.go
+++ b/apig/generate.go
@@ -497,6 +497,10 @@ func Generate(outDir, modelDir, targetFile string, all bool) int {
 			return 1
 		}
 	}
+	if err := generateRootController(detail, outDir); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return 1
+	}
 	if err := generateApibIndex(detail, outDir); err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		return 1

--- a/apig/generate.go
+++ b/apig/generate.go
@@ -229,6 +229,7 @@ func generateRootController(detail *Detail, outDir string) error {
 	}
 
 	src, err := format.Source(buf.Bytes())
+
 	if err != nil {
 		return err
 	}

--- a/apig/generate.go
+++ b/apig/generate.go
@@ -3,6 +3,7 @@ package apig
 import (
 	"bytes"
 	"fmt"
+	"go/format"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -227,6 +228,11 @@ func generateRootController(detail *Detail, outDir string) error {
 		return err
 	}
 
+	src, err := format.Source(buf.Bytes())
+	if err != nil {
+		return err
+	}
+
 	dstPath := filepath.Join(outDir, "controllers", "root.go")
 
 	if !util.FileExists(filepath.Dir(dstPath)) {
@@ -235,7 +241,7 @@ func generateRootController(detail *Detail, outDir string) error {
 		}
 	}
 
-	if err := ioutil.WriteFile(dstPath, buf.Bytes(), 0644); err != nil {
+	if err := ioutil.WriteFile(dstPath, src, 0644); err != nil {
 		return err
 	}
 

--- a/apig/testdata/controllers/root.go
+++ b/apig/testdata/controllers/root.go
@@ -8,7 +8,12 @@ import (
 )
 
 func APIEndpoints(c *gin.Context) {
-	reqScheme := c.Request.URL.Scheme
+	var reqScheme string
+	if c.Request.TLS != nil {
+		reqScheme = "https"
+	} else {
+		reqScheme = "http"
+	}
 	reqHost := c.Request.Host
 	baseURL := fmt.Sprintf("%s://%s", reqScheme, reqHost)
 

--- a/apig/testdata/controllers/root.go
+++ b/apig/testdata/controllers/root.go
@@ -9,11 +9,13 @@ import (
 
 func APIEndpoints(c *gin.Context) {
 	var reqScheme string
+
 	if c.Request.TLS != nil {
 		reqScheme = "https"
 	} else {
 		reqScheme = "http"
 	}
+
 	reqHost := c.Request.Host
 	baseURL := fmt.Sprintf("%s://%s", reqScheme, reqHost)
 


### PR DESCRIPTION
## WHAT

- Generate `_templates/root_controller.go.tmpl`.
- Fix the url schema in endpoint lists from the blank `""` to  `"http" or "https"`.