### PR TITLE
`omitempty` tag causes a panic

### DIFF
--- a/_example/helper/field.go
+++ b/_example/helper/field.go
@@ -114,6 +114,24 @@ func ParseFields(fields string) map[string]interface{} {
 	return result
 }
 
+func isEmptyValue(v reflect.Value) bool {
+	switch v.Kind() {
+	case reflect.Array, reflect.Map, reflect.Slice, reflect.String:
+		return v.Len() == 0
+	case reflect.Bool:
+		return !v.Bool()
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		return v.Int() == 0
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
+		return v.Uint() == 0
+	case reflect.Float32, reflect.Float64:
+		return v.Float() == 0
+	case reflect.Interface, reflect.Ptr:
+		return v.IsNil()
+	}
+	return false
+}
+
 func FieldToMap(model interface{}, fields map[string]interface{}) map[string]interface{} {
 	u := make(map[string]interface{})
 	ts, vs := reflect.TypeOf(model), reflect.ValueOf(model)
@@ -138,7 +156,7 @@ func FieldToMap(model interface{}, fields map[string]interface{}) map[string]int
 		}
 
 		if contains(fields, "*") {
-			if !omitEmpty || !vs.Field(i).IsNil() {
+			if !omitEmpty || !isEmptyValue(vs.Field(i)) {
 				u[jsonKey] = vs.Field(i).Interface()
 			}
 

--- a/_example/helper/field_test.go
+++ b/_example/helper/field_test.go
@@ -25,6 +25,15 @@ type Job struct {
 	RoleCd uint  `json:"role_cd" form:"role_cd"`
 }
 
+type Company struct {
+	ID           uint              `json:"id,omitempty" form:"id"`
+	Name         string            `json:"name,omitempty" form:"name"`
+	List         bool              `json:"list,omitempty" form:"list"`
+	Subsidiary   []*Company        `json:"company,omitempty" form:"company"`
+	Organization map[string]string `json:"organization,omitempty" form:"organization"`
+	User         *User             `json:"user,omitempty" form:"user"`
+}
+
 func TestQueryFields_Wildcard(t *testing.T) {
 	fields := map[string]interface{}{"*": nil}
 	result := QueryFields(User{}, fields)
@@ -301,6 +310,28 @@ func TestFieldToMap_OmitEmptyWithField(t *testing.T) {
 	}
 
 	for _, key := range []string{"profile"} {
+		if _, ok := result[key]; ok {
+			t.Fatalf("%s should not exist. actual: %#v", key, result)
+		}
+	}
+}
+
+func TestFieldToMap_OmitEmptyAllTypes(t *testing.T) {
+	company := Company{
+		ID:           0,
+		Name:         "",
+		List:         false,
+		Subsidiary:   []*Company{},
+		Organization: make(map[string]string),
+		User:         nil,
+	}
+
+	fields := map[string]interface{}{
+		"*": nil,
+	}
+	result := FieldToMap(company, fields)
+
+	for _, key := range []string{"id", "name", "list", "subsidiary", "organization", "user"} {
 		if _, ok := result[key]; ok {
 			t.Fatalf("%s should not exist. actual: %#v", key, result)
 		}

--- a/_templates/skeleton/helper/field.go.tmpl
+++ b/_templates/skeleton/helper/field.go.tmpl
@@ -114,6 +114,24 @@ func ParseFields(fields string) map[string]interface{} {
 	return result
 }
 
+func isEmptyValue(v reflect.Value) bool {
+	switch v.Kind() {
+	case reflect.Array, reflect.Map, reflect.Slice, reflect.String:
+		return v.Len() == 0
+	case reflect.Bool:
+		return !v.Bool()
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		return v.Int() == 0
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
+		return v.Uint() == 0
+	case reflect.Float32, reflect.Float64:
+		return v.Float() == 0
+	case reflect.Interface, reflect.Ptr:
+		return v.IsNil()
+	}
+	return false
+}
+
 func FieldToMap(model interface{}, fields map[string]interface{}) map[string]interface{} {
 	u := make(map[string]interface{})
 	ts, vs := reflect.TypeOf(model), reflect.ValueOf(model)
@@ -138,7 +156,7 @@ func FieldToMap(model interface{}, fields map[string]interface{}) map[string]int
 		}
 
 		if contains(fields, "*") {
-			if !omitEmpty || !vs.Field(i).IsNil() {
+			if !omitEmpty || !isEmptyValue(vs.Field(i)) {
 				u[jsonKey] = vs.Field(i).Interface()
 			}
 

--- a/_templates/skeleton/helper/field_test.go.tmpl
+++ b/_templates/skeleton/helper/field_test.go.tmpl
@@ -25,6 +25,15 @@ type Job struct {
 	RoleCd uint  `json:"role_cd" form:"role_cd"`
 }
 
+type Company struct {
+  ID           uint              `json:"id,omitempty" form:"id"`
+  Name         string            `json:"name,omitempty" form:"name"`
+  List         bool              `json:"list,omitempty" form:"list"`
+  Subsidiary   []*Company        `json:"company,omitempty" form:"company"`
+  Organization map[string]string `json:"organization,omitempty" form:"organization"`
+  User         *User             `json:"user,omitempty" form:"user"`
+}
+
 func TestQueryFields_Wildcard(t *testing.T) {
 	fields := map[string]interface{}{"*": nil}
 	result := QueryFields(User{}, fields)
@@ -305,6 +314,28 @@ func TestFieldToMap_OmitEmptyWithField(t *testing.T) {
 			t.Fatalf("%s should not exist. actual: %#v", key, result)
 		}
 	}
+}
+
+func TestFieldToMap_OmitEmptyAllTypes(t *testing.T) {
+  company := Company{
+    ID:           0,
+    Name:         "",
+    List:         false,
+    Subsidiary:   []*Company{},
+    Organization: make(map[string]string),
+    User:         nil,
+  }
+
+  fields := map[string]interface{}{
+    "*": nil,
+  }
+  result := FieldToMap(company, fields)
+
+  for _, key := range []string{"id", "name", "list", "subsidiary", "organization", "user"} {
+    if _, ok := result[key]; ok {
+      t.Fatalf("%s should not exist. actual: %#v", key, result)
+    }
+  }
 }
 
 func TestFieldToMap_SpecifyField(t *testing.T) {

--- a/_templates/skeleton/helper/field_test.go.tmpl
+++ b/_templates/skeleton/helper/field_test.go.tmpl
@@ -26,12 +26,12 @@ type Job struct {
 }
 
 type Company struct {
-  ID           uint              `json:"id,omitempty" form:"id"`
-  Name         string            `json:"name,omitempty" form:"name"`
-  List         bool              `json:"list,omitempty" form:"list"`
-  Subsidiary   []*Company        `json:"company,omitempty" form:"company"`
-  Organization map[string]string `json:"organization,omitempty" form:"organization"`
-  User         *User             `json:"user,omitempty" form:"user"`
+	ID           uint              `json:"id,omitempty" form:"id"`
+	Name         string            `json:"name,omitempty" form:"name"`
+	List         bool              `json:"list,omitempty" form:"list"`
+	Subsidiary   []*Company        `json:"company,omitempty" form:"company"`
+	Organization map[string]string `json:"organization,omitempty" form:"organization"`
+	User         *User             `json:"user,omitempty" form:"user"`
 }
 
 func TestQueryFields_Wildcard(t *testing.T) {
@@ -317,25 +317,25 @@ func TestFieldToMap_OmitEmptyWithField(t *testing.T) {
 }
 
 func TestFieldToMap_OmitEmptyAllTypes(t *testing.T) {
-  company := Company{
-    ID:           0,
-    Name:         "",
-    List:         false,
-    Subsidiary:   []*Company{},
-    Organization: make(map[string]string),
-    User:         nil,
-  }
+	company := Company{
+		ID:           0,
+		Name:         "",
+		List:         false,
+		Subsidiary:   []*Company{},
+		Organization: make(map[string]string),
+		User:         nil,
+	}
 
-  fields := map[string]interface{}{
-    "*": nil,
-  }
-  result := FieldToMap(company, fields)
+	fields := map[string]interface{}{
+		"*": nil,
+	}
+	result := FieldToMap(company, fields)
 
-  for _, key := range []string{"id", "name", "list", "subsidiary", "organization", "user"} {
-    if _, ok := result[key]; ok {
-      t.Fatalf("%s should not exist. actual: %#v", key, result)
-    }
-  }
+	for _, key := range []string{"id", "name", "list", "subsidiary", "organization", "user"} {
+		if _, ok := result[key]; ok {
+			t.Fatalf("%s should not exist. actual: %#v", key, result)
+		}
+	}
 }
 
 func TestFieldToMap_SpecifyField(t *testing.T) {


### PR DESCRIPTION
## WHY
`omitempty` tag causes a panic in some types of field.

- int, string, ...

The reason is that `reflect.value.isNil()` cannot use these types.

## WHAT

Add `isEmptyValue` method.