### PR TITLE
Passing arguments to ... parameters

### DIFF
--- a/msg/msg.go
+++ b/msg/msg.go
@@ -8,12 +8,12 @@ var Mute = false
 
 func Printf(format string, a ...interface{}) {
 	if !Mute {
-		fmt.Printf(format, a)
+		fmt.Printf(format, a...)
 	}
 }
 
 func Println(a ...interface{}) {
 	if !Mute {
-		fmt.Println(a)
+		fmt.Println(a...)
 	}
 }


### PR DESCRIPTION
## WHY

in `apig gen command`, `%!s(MISSING)` appeared.

```
[create /Users/takagi_go/go/src/github.com/shimastripe/fieldsquery/README.md aaa] %!s(MISSING)
```

## WHAT

Pass the expanded slice to the function.