### PR TITLE
fields query cause panic.

### DIFF
--- a/_example/controllers/company.go
+++ b/_example/controllers/company.go
@@ -58,7 +58,7 @@ func GetCompanies(c *gin.Context) {
 		// 1.0.0 <= this version < 2.0.0 !!
 	}
 
-	fieldMapArr := []map[string]interface{}{}
+	fieldMaps := []map[string]interface{}{}
 	for _, company := range companies {
 		fieldMap, err := helper.FieldToMap(company, fields)
 
@@ -67,14 +67,14 @@ func GetCompanies(c *gin.Context) {
 			return
 		}
 
-		fieldMapArr = append(fieldMapArr, fieldMap)
+		fieldMaps = append(fieldMaps, fieldMap)
 	}
 
 	_, ok := c.GetQuery("pretty")
 	if ok {
-		c.IndentedJSON(200, fieldMapArr)
+		c.IndentedJSON(200, fieldMaps)
 	} else {
-		c.JSON(200, fieldMapArr)
+		c.JSON(200, fieldMaps)
 	}
 }
 

--- a/_example/controllers/company.go
+++ b/_example/controllers/company.go
@@ -58,16 +58,23 @@ func GetCompanies(c *gin.Context) {
 		// 1.0.0 <= this version < 2.0.0 !!
 	}
 
-	fieldMap := []map[string]interface{}{}
+	fieldMapArr := []map[string]interface{}{}
 	for _, company := range companies {
-		fieldMap = append(fieldMap, helper.FieldToMap(company, fields))
+		fieldMap, err := helper.FieldToMap(company, fields)
+
+		if err != nil {
+			c.JSON(400, gin.H{"error": err.Error()})
+			return
+		}
+
+		fieldMapArr = append(fieldMapArr, fieldMap)
 	}
 
 	_, ok := c.GetQuery("pretty")
 	if ok {
-		c.IndentedJSON(200, fieldMap)
+		c.IndentedJSON(200, fieldMapArr)
 	} else {
-		c.JSON(200, fieldMap)
+		c.JSON(200, fieldMapArr)
 	}
 }
 
@@ -98,7 +105,12 @@ func GetCompany(c *gin.Context) {
 		// 1.0.0 <= this version < 2.0.0 !!
 	}
 
-	fieldMap := helper.FieldToMap(company, fields)
+	fieldMap, err := helper.FieldToMap(company, fields)
+
+	if err != nil {
+		c.JSON(400, gin.H{"error": err.Error()})
+		return
+	}
 
 	_, ok := c.GetQuery("pretty")
 	if ok {

--- a/_example/controllers/email.go
+++ b/_example/controllers/email.go
@@ -58,7 +58,7 @@ func GetEmails(c *gin.Context) {
 		// 1.0.0 <= this version < 2.0.0 !!
 	}
 
-	fieldMapArr := []map[string]interface{}{}
+	fieldMaps := []map[string]interface{}{}
 	for _, email := range emails {
 		fieldMap, err := helper.FieldToMap(email, fields)
 
@@ -67,14 +67,14 @@ func GetEmails(c *gin.Context) {
 			return
 		}
 
-		fieldMapArr = append(fieldMapArr, fieldMap)
+		fieldMaps = append(fieldMaps, fieldMap)
 	}
 
 	_, ok := c.GetQuery("pretty")
 	if ok {
-		c.IndentedJSON(200, fieldMapArr)
+		c.IndentedJSON(200, fieldMaps)
 	} else {
-		c.JSON(200, fieldMapArr)
+		c.JSON(200, fieldMaps)
 	}
 }
 

--- a/_example/controllers/email.go
+++ b/_example/controllers/email.go
@@ -58,16 +58,23 @@ func GetEmails(c *gin.Context) {
 		// 1.0.0 <= this version < 2.0.0 !!
 	}
 
-	fieldMap := []map[string]interface{}{}
+	fieldMapArr := []map[string]interface{}{}
 	for _, email := range emails {
-		fieldMap = append(fieldMap, helper.FieldToMap(email, fields))
+		fieldMap, err := helper.FieldToMap(email, fields)
+
+		if err != nil {
+			c.JSON(400, gin.H{"error": err.Error()})
+			return
+		}
+
+		fieldMapArr = append(fieldMapArr, fieldMap)
 	}
 
 	_, ok := c.GetQuery("pretty")
 	if ok {
-		c.IndentedJSON(200, fieldMap)
+		c.IndentedJSON(200, fieldMapArr)
 	} else {
-		c.JSON(200, fieldMap)
+		c.JSON(200, fieldMapArr)
 	}
 }
 
@@ -98,7 +105,12 @@ func GetEmail(c *gin.Context) {
 		// 1.0.0 <= this version < 2.0.0 !!
 	}
 
-	fieldMap := helper.FieldToMap(email, fields)
+	fieldMap, err := helper.FieldToMap(email, fields)
+
+	if err != nil {
+		c.JSON(400, gin.H{"error": err.Error()})
+		return
+	}
 
 	_, ok := c.GetQuery("pretty")
 	if ok {

--- a/_example/controllers/job.go
+++ b/_example/controllers/job.go
@@ -58,7 +58,7 @@ func GetJobs(c *gin.Context) {
 		// 1.0.0 <= this version < 2.0.0 !!
 	}
 
-	fieldMapArr := []map[string]interface{}{}
+	fieldMaps := []map[string]interface{}{}
 	for _, job := range jobs {
 		fieldMap, err := helper.FieldToMap(job, fields)
 
@@ -67,14 +67,14 @@ func GetJobs(c *gin.Context) {
 			return
 		}
 
-		fieldMapArr = append(fieldMapArr, fieldMap)
+		fieldMaps = append(fieldMaps, fieldMap)
 	}
 
 	_, ok := c.GetQuery("pretty")
 	if ok {
-		c.IndentedJSON(200, fieldMapArr)
+		c.IndentedJSON(200, fieldMaps)
 	} else {
-		c.JSON(200, fieldMapArr)
+		c.JSON(200, fieldMaps)
 	}
 }
 

--- a/_example/controllers/job.go
+++ b/_example/controllers/job.go
@@ -58,16 +58,23 @@ func GetJobs(c *gin.Context) {
 		// 1.0.0 <= this version < 2.0.0 !!
 	}
 
-	fieldMap := []map[string]interface{}{}
+	fieldMapArr := []map[string]interface{}{}
 	for _, job := range jobs {
-		fieldMap = append(fieldMap, helper.FieldToMap(job, fields))
+		fieldMap, err := helper.FieldToMap(job, fields)
+
+		if err != nil {
+			c.JSON(400, gin.H{"error": err.Error()})
+			return
+		}
+
+		fieldMapArr = append(fieldMapArr, fieldMap)
 	}
 
 	_, ok := c.GetQuery("pretty")
 	if ok {
-		c.IndentedJSON(200, fieldMap)
+		c.IndentedJSON(200, fieldMapArr)
 	} else {
-		c.JSON(200, fieldMap)
+		c.JSON(200, fieldMapArr)
 	}
 }
 
@@ -98,7 +105,12 @@ func GetJob(c *gin.Context) {
 		// 1.0.0 <= this version < 2.0.0 !!
 	}
 
-	fieldMap := helper.FieldToMap(job, fields)
+	fieldMap, err := helper.FieldToMap(job, fields)
+
+	if err != nil {
+		c.JSON(400, gin.H{"error": err.Error()})
+		return
+	}
 
 	_, ok := c.GetQuery("pretty")
 	if ok {

--- a/_example/controllers/profile.go
+++ b/_example/controllers/profile.go
@@ -58,16 +58,23 @@ func GetProfiles(c *gin.Context) {
 		// 1.0.0 <= this version < 2.0.0 !!
 	}
 
-	fieldMap := []map[string]interface{}{}
+	fieldMapArr := []map[string]interface{}{}
 	for _, profile := range profiles {
-		fieldMap = append(fieldMap, helper.FieldToMap(profile, fields))
+		fieldMap, err := helper.FieldToMap(profile, fields)
+
+		if err != nil {
+			c.JSON(400, gin.H{"error": err.Error()})
+			return
+		}
+
+		fieldMapArr = append(fieldMapArr, fieldMap)
 	}
 
 	_, ok := c.GetQuery("pretty")
 	if ok {
-		c.IndentedJSON(200, fieldMap)
+		c.IndentedJSON(200, fieldMapArr)
 	} else {
-		c.JSON(200, fieldMap)
+		c.JSON(200, fieldMapArr)
 	}
 }
 
@@ -98,7 +105,12 @@ func GetProfile(c *gin.Context) {
 		// 1.0.0 <= this version < 2.0.0 !!
 	}
 
-	fieldMap := helper.FieldToMap(profile, fields)
+	fieldMap, err := helper.FieldToMap(profile, fields)
+
+	if err != nil {
+		c.JSON(400, gin.H{"error": err.Error()})
+		return
+	}
 
 	_, ok := c.GetQuery("pretty")
 	if ok {

--- a/_example/controllers/profile.go
+++ b/_example/controllers/profile.go
@@ -58,7 +58,7 @@ func GetProfiles(c *gin.Context) {
 		// 1.0.0 <= this version < 2.0.0 !!
 	}
 
-	fieldMapArr := []map[string]interface{}{}
+	fieldMaps := []map[string]interface{}{}
 	for _, profile := range profiles {
 		fieldMap, err := helper.FieldToMap(profile, fields)
 
@@ -67,14 +67,14 @@ func GetProfiles(c *gin.Context) {
 			return
 		}
 
-		fieldMapArr = append(fieldMapArr, fieldMap)
+		fieldMaps = append(fieldMaps, fieldMap)
 	}
 
 	_, ok := c.GetQuery("pretty")
 	if ok {
-		c.IndentedJSON(200, fieldMapArr)
+		c.IndentedJSON(200, fieldMaps)
 	} else {
-		c.JSON(200, fieldMapArr)
+		c.JSON(200, fieldMaps)
 	}
 }
 

--- a/_example/controllers/user.go
+++ b/_example/controllers/user.go
@@ -58,7 +58,7 @@ func GetUsers(c *gin.Context) {
 		// 1.0.0 <= this version < 2.0.0 !!
 	}
 
-	fieldMapArr := []map[string]interface{}{}
+	fieldMaps := []map[string]interface{}{}
 	for _, user := range users {
 		fieldMap, err := helper.FieldToMap(user, fields)
 
@@ -67,14 +67,14 @@ func GetUsers(c *gin.Context) {
 			return
 		}
 
-		fieldMapArr = append(fieldMapArr, fieldMap)
+		fieldMaps = append(fieldMaps, fieldMap)
 	}
 
 	_, ok := c.GetQuery("pretty")
 	if ok {
-		c.IndentedJSON(200, fieldMapArr)
+		c.IndentedJSON(200, fieldMaps)
 	} else {
-		c.JSON(200, fieldMapArr)
+		c.JSON(200, fieldMaps)
 	}
 }
 

--- a/_example/controllers/user.go
+++ b/_example/controllers/user.go
@@ -58,16 +58,23 @@ func GetUsers(c *gin.Context) {
 		// 1.0.0 <= this version < 2.0.0 !!
 	}
 
-	fieldMap := []map[string]interface{}{}
+	fieldMapArr := []map[string]interface{}{}
 	for _, user := range users {
-		fieldMap = append(fieldMap, helper.FieldToMap(user, fields))
+		fieldMap, err := helper.FieldToMap(user, fields)
+
+		if err != nil {
+			c.JSON(400, gin.H{"error": err.Error()})
+			return
+		}
+
+		fieldMapArr = append(fieldMapArr, fieldMap)
 	}
 
 	_, ok := c.GetQuery("pretty")
 	if ok {
-		c.IndentedJSON(200, fieldMap)
+		c.IndentedJSON(200, fieldMapArr)
 	} else {
-		c.JSON(200, fieldMap)
+		c.JSON(200, fieldMapArr)
 	}
 }
 
@@ -98,7 +105,12 @@ func GetUser(c *gin.Context) {
 		// 1.0.0 <= this version < 2.0.0 !!
 	}
 
-	fieldMap := helper.FieldToMap(user, fields)
+	fieldMap, err := helper.FieldToMap(user, fields)
+
+	if err != nil {
+		c.JSON(400, gin.H{"error": err.Error()})
+		return
+	}
 
 	_, ok := c.GetQuery("pretty")
 	if ok {

--- a/_example/helper/field.go
+++ b/_example/helper/field.go
@@ -143,9 +143,11 @@ func FieldToMap(model interface{}, fields map[string]interface{}) (map[string]in
 		return nil, errors.New("Invalid Parameter. The specified parameter does not have a structure.")
 	}
 
-	for field, _ := range fields {
-		if !vs.FieldByName(snaker.SnakeToCamel(field)).IsValid() {
-			return nil, errors.New("Invalid Parameter. The specified field does not exist.")
+	if !contains(fields, "*") {
+		for field, _ := range fields {
+			if !vs.FieldByName(snaker.SnakeToCamel(field)).IsValid() {
+				return nil, errors.New("Invalid Parameter. The specified field does not exist.")
+			}
 		}
 	}
 

--- a/_example/helper/field.go
+++ b/_example/helper/field.go
@@ -178,18 +178,19 @@ func FieldToMap(model interface{}, fields map[string]interface{}) (map[string]in
 
 		if contains(fields, jsonKey) {
 			v := fields[jsonKey]
-			var err error
 
 			if vs.Field(i).Kind() == reflect.Ptr {
 				if !vs.Field(i).IsNil() {
 					if v == nil {
 						u[jsonKey] = vs.Field(i).Elem().Interface()
 					} else {
-						u[jsonKey], err = FieldToMap(vs.Field(i).Elem().Interface(), v.(map[string]interface{}))
+						k, err := FieldToMap(vs.Field(i).Elem().Interface(), v.(map[string]interface{}))
 
 						if err != nil {
 							return nil, err
 						}
+
+						u[jsonKey] = k
 					}
 				} else {
 					if v == nil {
@@ -206,24 +207,25 @@ func FieldToMap(model interface{}, fields map[string]interface{}) (map[string]in
 					if v == nil {
 						fieldMap = append(fieldMap, s.Index(i).Interface())
 					} else {
-						nestFieldMap := make(map[string]interface{})
 
 						if s.Index(i).Kind() == reflect.Ptr {
-							nestFieldMap, err = FieldToMap(s.Index(i).Elem().Interface(), v.(map[string]interface{}))
+							k, err := FieldToMap(s.Index(i).Elem().Interface(), v.(map[string]interface{}))
 
 							if err != nil {
 								return nil, err
 							}
+
+							fieldMap = append(fieldMap, k)
 						} else {
-							nestFieldMap, err = FieldToMap(s.Index(i).Interface(), v.(map[string]interface{}))
+							k, err := FieldToMap(s.Index(i).Interface(), v.(map[string]interface{}))
 
 							if err != nil {
 								return nil, err
 							}
-						}
-						fieldMap = append(fieldMap, nestFieldMap)
-					}
 
+							fieldMap = append(fieldMap, k)
+						}
+					}
 				}
 
 				u[jsonKey] = fieldMap
@@ -231,14 +233,13 @@ func FieldToMap(model interface{}, fields map[string]interface{}) (map[string]in
 				if v == nil {
 					u[jsonKey] = vs.Field(i).Interface()
 				} else {
-					nestFieldMap := make(map[string]interface{})
-					nestFieldMap, err = FieldToMap(vs.Field(i).Interface(), v.(map[string]interface{}))
+					k, err := FieldToMap(vs.Field(i).Interface(), v.(map[string]interface{}))
 
 					if err != nil {
 						return nil, err
 					}
 
-					u[jsonKey] = nestFieldMap
+					u[jsonKey] = k
 				}
 			}
 		}

--- a/_example/helper/field.go
+++ b/_example/helper/field.go
@@ -186,6 +186,10 @@ func FieldToMap(model interface{}, fields map[string]interface{}) (map[string]in
 						u[jsonKey] = vs.Field(i).Elem().Interface()
 					} else {
 						u[jsonKey], err = FieldToMap(vs.Field(i).Elem().Interface(), v.(map[string]interface{}))
+
+						if err != nil {
+							return nil, err
+						}
 					}
 				} else {
 					if v == nil {
@@ -206,15 +210,18 @@ func FieldToMap(model interface{}, fields map[string]interface{}) (map[string]in
 
 						if s.Index(i).Kind() == reflect.Ptr {
 							nestFieldMap, err = FieldToMap(s.Index(i).Elem().Interface(), v.(map[string]interface{}))
+
+							if err != nil {
+								return nil, err
+							}
 						} else {
 							nestFieldMap, err = FieldToMap(s.Index(i).Interface(), v.(map[string]interface{}))
-						}
 
+							if err != nil {
+								return nil, err
+							}
+						}
 						fieldMap = append(fieldMap, nestFieldMap)
-
-						if err != nil {
-							return nil, err
-						}
 					}
 
 				}
@@ -226,15 +233,15 @@ func FieldToMap(model interface{}, fields map[string]interface{}) (map[string]in
 				} else {
 					nestFieldMap := make(map[string]interface{})
 					nestFieldMap, err = FieldToMap(vs.Field(i).Interface(), v.(map[string]interface{}))
+
+					if err != nil {
+						return nil, err
+					}
+
 					u[jsonKey] = nestFieldMap
 				}
 			}
-
-			if err != nil {
-				return nil, err
-			}
 		}
-
 	}
 
 	return u, nil

--- a/_templates/controller.go.tmpl
+++ b/_templates/controller.go.tmpl
@@ -58,7 +58,7 @@ func Get{{ pluralize .Model.Name }}(c *gin.Context) {
 		// 1.0.0 <= this version < 2.0.0 !!
 	}
 
-	fieldMapArr := []map[string]interface{}{}
+	fieldMaps := []map[string]interface{}{}
 	for _, {{ tolower .Model.Name }} := range {{ pluralize (tolower .Model.Name) }} {
 		fieldMap, err := helper.FieldToMap({{ tolower .Model.Name }}, fields)
 
@@ -67,14 +67,14 @@ func Get{{ pluralize .Model.Name }}(c *gin.Context) {
 			return
 		}
 
-		fieldMapArr = append(fieldMapArr, fieldMap)
+		fieldMaps = append(fieldMaps, fieldMap)
 	}
 
 	_, ok := c.GetQuery("pretty")
 	if ok {
-		c.IndentedJSON(200, fieldMapArr)
+		c.IndentedJSON(200, fieldMaps)
 	} else {
-		c.JSON(200, fieldMapArr)
+		c.JSON(200, fieldMaps)
 	}
 }
 

--- a/_templates/controller.go.tmpl
+++ b/_templates/controller.go.tmpl
@@ -58,16 +58,23 @@ func Get{{ pluralize .Model.Name }}(c *gin.Context) {
 		// 1.0.0 <= this version < 2.0.0 !!
 	}
 
-	fieldMap := []map[string]interface{}{}
+	fieldMapArr := []map[string]interface{}{}
 	for _, {{ tolower .Model.Name }} := range {{ pluralize (tolower .Model.Name) }} {
-		fieldMap = append(fieldMap, helper.FieldToMap({{ tolower .Model.Name }}, fields))
+		fieldMap, err := helper.FieldToMap({{ tolower .Model.Name }}, fields)
+
+		if err != nil {
+			c.JSON(400, gin.H{"error": err.Error()})
+			return
+		}
+
+		fieldMapArr = append(fieldMapArr, fieldMap)
 	}
 
 	_, ok := c.GetQuery("pretty")
 	if ok {
-		c.IndentedJSON(200, fieldMap)
+		c.IndentedJSON(200, fieldMapArr)
 	} else {
-		c.JSON(200, fieldMap)
+		c.JSON(200, fieldMapArr)
 	}
 }
 
@@ -98,7 +105,12 @@ func Get{{ .Model.Name }}(c *gin.Context) {
 		// 1.0.0 <= this version < 2.0.0 !!
 	}
 
-	fieldMap := helper.FieldToMap({{ tolower .Model.Name }}, fields)
+	fieldMap, err := helper.FieldToMap({{ tolower .Model.Name }}, fields)
+
+	if err != nil {
+		c.JSON(400, gin.H{"error": err.Error()})
+		return
+	}
 
 	_, ok := c.GetQuery("pretty")
 	if ok {

--- a/_templates/skeleton/helper/field.go.tmpl
+++ b/_templates/skeleton/helper/field.go.tmpl
@@ -143,9 +143,11 @@ func FieldToMap(model interface{}, fields map[string]interface{}) (map[string]in
 		return nil, errors.New("Invalid Parameter. The specified parameter does not have a structure.")
 	}
 
-	for field, _ := range fields {
-		if !vs.FieldByName(snaker.SnakeToCamel(field)).IsValid() {
-			return nil, errors.New("Invalid Parameter. The specified field does not exist.")
+	if !contains(fields, "*") {
+		for field, _ := range fields {
+			if !vs.FieldByName(snaker.SnakeToCamel(field)).IsValid() {
+				return nil, errors.New("Invalid Parameter. The specified field does not exist.")
+			}
 		}
 	}
 

--- a/_templates/skeleton/helper/field.go.tmpl
+++ b/_templates/skeleton/helper/field.go.tmpl
@@ -178,18 +178,19 @@ func FieldToMap(model interface{}, fields map[string]interface{}) (map[string]in
 
 		if contains(fields, jsonKey) {
 			v := fields[jsonKey]
-			var err error
 
 			if vs.Field(i).Kind() == reflect.Ptr {
 				if !vs.Field(i).IsNil() {
 					if v == nil {
 						u[jsonKey] = vs.Field(i).Elem().Interface()
 					} else {
-						u[jsonKey], err = FieldToMap(vs.Field(i).Elem().Interface(), v.(map[string]interface{}))
+						k, err := FieldToMap(vs.Field(i).Elem().Interface(), v.(map[string]interface{}))
 
 						if err != nil {
 							return nil, err
 						}
+
+						u[jsonKey] = k
 					}
 				} else {
 					if v == nil {
@@ -206,24 +207,25 @@ func FieldToMap(model interface{}, fields map[string]interface{}) (map[string]in
 					if v == nil {
 						fieldMap = append(fieldMap, s.Index(i).Interface())
 					} else {
-						nestFieldMap := make(map[string]interface{})
 
 						if s.Index(i).Kind() == reflect.Ptr {
-							nestFieldMap, err = FieldToMap(s.Index(i).Elem().Interface(), v.(map[string]interface{}))
+							k, err := FieldToMap(s.Index(i).Elem().Interface(), v.(map[string]interface{}))
 
 							if err != nil {
 								return nil, err
 							}
+
+							fieldMap = append(fieldMap, k)
 						} else {
-							nestFieldMap, err = FieldToMap(s.Index(i).Interface(), v.(map[string]interface{}))
+							k, err := FieldToMap(s.Index(i).Interface(), v.(map[string]interface{}))
 
 							if err != nil {
 								return nil, err
 							}
-						}
-						fieldMap = append(fieldMap, nestFieldMap)
-					}
 
+							fieldMap = append(fieldMap, k)
+						}
+					}
 				}
 
 				u[jsonKey] = fieldMap
@@ -231,14 +233,13 @@ func FieldToMap(model interface{}, fields map[string]interface{}) (map[string]in
 				if v == nil {
 					u[jsonKey] = vs.Field(i).Interface()
 				} else {
-					nestFieldMap := make(map[string]interface{})
-					nestFieldMap, err = FieldToMap(vs.Field(i).Interface(), v.(map[string]interface{}))
+					k, err := FieldToMap(vs.Field(i).Interface(), v.(map[string]interface{}))
 
 					if err != nil {
 						return nil, err
 					}
 
-					u[jsonKey] = nestFieldMap
+					u[jsonKey] = k
 				}
 			}
 		}

--- a/_templates/skeleton/helper/field.go.tmpl
+++ b/_templates/skeleton/helper/field.go.tmpl
@@ -186,6 +186,10 @@ func FieldToMap(model interface{}, fields map[string]interface{}) (map[string]in
 						u[jsonKey] = vs.Field(i).Elem().Interface()
 					} else {
 						u[jsonKey], err = FieldToMap(vs.Field(i).Elem().Interface(), v.(map[string]interface{}))
+
+						if err != nil {
+							return nil, err
+						}
 					}
 				} else {
 					if v == nil {
@@ -206,15 +210,18 @@ func FieldToMap(model interface{}, fields map[string]interface{}) (map[string]in
 
 						if s.Index(i).Kind() == reflect.Ptr {
 							nestFieldMap, err = FieldToMap(s.Index(i).Elem().Interface(), v.(map[string]interface{}))
+
+							if err != nil {
+								return nil, err
+							}
 						} else {
 							nestFieldMap, err = FieldToMap(s.Index(i).Interface(), v.(map[string]interface{}))
-						}
 
+							if err != nil {
+								return nil, err
+							}
+						}
 						fieldMap = append(fieldMap, nestFieldMap)
-
-						if err != nil {
-							return nil, err
-						}
 					}
 
 				}
@@ -226,15 +233,15 @@ func FieldToMap(model interface{}, fields map[string]interface{}) (map[string]in
 				} else {
 					nestFieldMap := make(map[string]interface{})
 					nestFieldMap, err = FieldToMap(vs.Field(i).Interface(), v.(map[string]interface{}))
+
+					if err != nil {
+						return nil, err
+					}
+
 					u[jsonKey] = nestFieldMap
 				}
 			}
-
-			if err != nil {
-				return nil, err
-			}
 		}
-
 	}
 
 	return u, nil

--- a/apig/testdata/controllers/user.go
+++ b/apig/testdata/controllers/user.go
@@ -58,7 +58,7 @@ func GetUsers(c *gin.Context) {
 		// 1.0.0 <= this version < 2.0.0 !!
 	}
 
-	fieldMapArr := []map[string]interface{}{}
+	fieldMaps := []map[string]interface{}{}
 	for _, user := range users {
 		fieldMap, err := helper.FieldToMap(user, fields)
 
@@ -67,14 +67,14 @@ func GetUsers(c *gin.Context) {
 			return
 		}
 
-		fieldMapArr = append(fieldMapArr, fieldMap)
+		fieldMaps = append(fieldMaps, fieldMap)
 	}
 
 	_, ok := c.GetQuery("pretty")
 	if ok {
-		c.IndentedJSON(200, fieldMapArr)
+		c.IndentedJSON(200, fieldMaps)
 	} else {
-		c.JSON(200, fieldMapArr)
+		c.JSON(200, fieldMaps)
 	}
 }
 

--- a/apig/testdata/controllers/user.go
+++ b/apig/testdata/controllers/user.go
@@ -58,16 +58,23 @@ func GetUsers(c *gin.Context) {
 		// 1.0.0 <= this version < 2.0.0 !!
 	}
 
-	fieldMap := []map[string]interface{}{}
+	fieldMapArr := []map[string]interface{}{}
 	for _, user := range users {
-		fieldMap = append(fieldMap, helper.FieldToMap(user, fields))
+		fieldMap, err := helper.FieldToMap(user, fields)
+
+		if err != nil {
+			c.JSON(400, gin.H{"error": err.Error()})
+			return
+		}
+
+		fieldMapArr = append(fieldMapArr, fieldMap)
 	}
 
 	_, ok := c.GetQuery("pretty")
 	if ok {
-		c.IndentedJSON(200, fieldMap)
+		c.IndentedJSON(200, fieldMapArr)
 	} else {
-		c.JSON(200, fieldMap)
+		c.JSON(200, fieldMapArr)
 	}
 }
 
@@ -98,7 +105,12 @@ func GetUser(c *gin.Context) {
 		// 1.0.0 <= this version < 2.0.0 !!
 	}
 
-	fieldMap := helper.FieldToMap(user, fields)
+	fieldMap, err := helper.FieldToMap(user, fields)
+
+	if err != nil {
+		c.JSON(400, gin.H{"error": err.Error()})
+		return
+	}
 
 	_, ok := c.GetQuery("pretty")
 	if ok {


### PR DESCRIPTION
## WHY

- fields query cause a panic and unpleasant behaviors.

Current status is as follows.

1. When the nest of the source is not a structure, panic occurs.

    ```
    ?fields=id.id
    ```

1. When specify a nonexistent field, it is ignored.

    ```
    ?fields=id,hogehoge
    ```

    ```json
    [
        {
            "id": 1
        }
    ]
    ```

1. It should return error if nest query is specified in spite of the structure is null.

    ```go
    User{
        AccountName: null,
    }
    ```

    ```
    ?fields=account_name.id
    ```

    ```json
        [
            {
                "account_name": null
            }
        ]
    ```

## WHAT

1. Checked the type of argument.
2. Checked the specified field whether it exists in the structure.
3. Checked whether the structure and the specified field is null or not.