### PR TITLE
Add pagination error handling

### DIFF
--- a/_example/controllers/company.go
+++ b/_example/controllers/company.go
@@ -14,6 +14,7 @@ import (
 
 func GetCompanies(c *gin.Context) {
 	ver, err := version.New(c)
+
 	if err != nil {
 		c.JSON(400, gin.H{"error": err.Error()})
 		return
@@ -51,7 +52,11 @@ func GetCompanies(c *gin.Context) {
 	} else {
 		index = int(companies[len(companies)-1].ID)
 	}
-	pagination.SetHeaderLink(c, index)
+
+	if err := pagination.SetHeaderLink(c, index); err != nil {
+		c.JSON(400, gin.H{"error": err.Error()})
+		return
+	}
 
 	if version.Range("1.0.0", "<=", ver) && version.Range(ver, "<", "2.0.0") {
 		// conditional branch by version.

--- a/_example/controllers/email.go
+++ b/_example/controllers/email.go
@@ -14,6 +14,7 @@ import (
 
 func GetEmails(c *gin.Context) {
 	ver, err := version.New(c)
+
 	if err != nil {
 		c.JSON(400, gin.H{"error": err.Error()})
 		return
@@ -51,7 +52,11 @@ func GetEmails(c *gin.Context) {
 	} else {
 		index = int(emails[len(emails)-1].ID)
 	}
-	pagination.SetHeaderLink(c, index)
+
+	if err := pagination.SetHeaderLink(c, index); err != nil {
+		c.JSON(400, gin.H{"error": err.Error()})
+		return
+	}
 
 	if version.Range("1.0.0", "<=", ver) && version.Range(ver, "<", "2.0.0") {
 		// conditional branch by version.

--- a/_example/controllers/job.go
+++ b/_example/controllers/job.go
@@ -14,6 +14,7 @@ import (
 
 func GetJobs(c *gin.Context) {
 	ver, err := version.New(c)
+
 	if err != nil {
 		c.JSON(400, gin.H{"error": err.Error()})
 		return
@@ -51,7 +52,11 @@ func GetJobs(c *gin.Context) {
 	} else {
 		index = int(jobs[len(jobs)-1].ID)
 	}
-	pagination.SetHeaderLink(c, index)
+
+	if err := pagination.SetHeaderLink(c, index); err != nil {
+		c.JSON(400, gin.H{"error": err.Error()})
+		return
+	}
 
 	if version.Range("1.0.0", "<=", ver) && version.Range(ver, "<", "2.0.0") {
 		// conditional branch by version.

--- a/_example/controllers/profile.go
+++ b/_example/controllers/profile.go
@@ -14,6 +14,7 @@ import (
 
 func GetProfiles(c *gin.Context) {
 	ver, err := version.New(c)
+
 	if err != nil {
 		c.JSON(400, gin.H{"error": err.Error()})
 		return
@@ -51,7 +52,11 @@ func GetProfiles(c *gin.Context) {
 	} else {
 		index = int(profiles[len(profiles)-1].ID)
 	}
-	pagination.SetHeaderLink(c, index)
+
+	if err := pagination.SetHeaderLink(c, index); err != nil {
+		c.JSON(400, gin.H{"error": err.Error()})
+		return
+	}
 
 	if version.Range("1.0.0", "<=", ver) && version.Range(ver, "<", "2.0.0") {
 		// conditional branch by version.

--- a/_example/controllers/user.go
+++ b/_example/controllers/user.go
@@ -14,6 +14,7 @@ import (
 
 func GetUsers(c *gin.Context) {
 	ver, err := version.New(c)
+
 	if err != nil {
 		c.JSON(400, gin.H{"error": err.Error()})
 		return
@@ -51,7 +52,11 @@ func GetUsers(c *gin.Context) {
 	} else {
 		index = int(users[len(users)-1].ID)
 	}
-	pagination.SetHeaderLink(c, index)
+
+	if err := pagination.SetHeaderLink(c, index); err != nil {
+		c.JSON(400, gin.H{"error": err.Error()})
+		return
+	}
 
 	if version.Range("1.0.0", "<=", ver) && version.Range(ver, "<", "2.0.0") {
 		// conditional branch by version.

--- a/_example/db/pagination.go
+++ b/_example/db/pagination.go
@@ -76,16 +76,20 @@ func (p *Pagination) SetHeaderLink(c *gin.Context, index int) error {
 		return errors.New("Pagination struct got nil.")
 	}
 
-	var link string
+	reqScheme := "http"
 
-	if p.LastID != 0 {
-		link = fmt.Sprintf("<http://%v%v?limit=%v&last_id=%v&order=%v>; rel=\"next\"", c.Request.Host, c.Request.URL.Path, p.Limit, index, p.Order)
-	} else {
+	if c.Request.TLS != nil {
+		reqScheme = "https"
+	}
+
+	link := fmt.Sprintf("<%s://%v%v?limit=%v&last_id=%v&order=%v>; rel=\"next\"", reqScheme, c.Request.Host, c.Request.URL.Path, p.Limit, index, p.Order)
+
+	if p.LastID == 0 {
 		if p.Page == 1 {
-			link = fmt.Sprintf("<http://%v%v?limit=%v&page=%v>; rel=\"next\"", c.Request.Host, c.Request.URL.Path, p.Limit, p.Page+1)
+			link = fmt.Sprintf("<%s://%v%v?limit=%v&page=%v>; rel=\"next\"", reqScheme, c.Request.Host, c.Request.URL.Path, p.Limit, p.Page+1)
 		} else {
 			link = fmt.Sprintf(
-				"<http://%v%v?limit=%v&page=%v>; rel=\"next\",<http://%v%v?limit=%v&page=%v>; rel=\"prev\"",
+				"<%s://%v%v?limit=%v&page=%v>; rel=\"next\",<http://%v%v?limit=%v&page=%v>; rel=\"prev\"", reqScheme,
 				c.Request.Host, c.Request.URL.Path, p.Limit, p.Page+1, c.Request.Host, c.Request.URL.Path, p.Limit, p.Page-1,
 			)
 		}

--- a/_example/db/pagination.go
+++ b/_example/db/pagination.go
@@ -1,6 +1,7 @@
 package db
 
 import (
+	"errors"
 	"fmt"
 	"math"
 	"strconv"
@@ -24,6 +25,10 @@ type Pagination struct {
 }
 
 func (p *Pagination) Paginate(c *gin.Context) (*gorm.DB, error) {
+	if p == nil {
+		return nil, errors.New("Pagination struct got nil.")
+	}
+
 	db := DBInstance(c)
 	limitQuery := c.DefaultQuery("limit", defaultLimit)
 	pageQuery := c.DefaultQuery("page", defaultPage)
@@ -32,6 +37,7 @@ func (p *Pagination) Paginate(c *gin.Context) (*gorm.DB, error) {
 	p.Order = c.DefaultQuery("order", defaultOrder)
 
 	limit, err := strconv.Atoi(limitQuery)
+
 	if err != nil {
 		return db, err
 	}
@@ -40,6 +46,7 @@ func (p *Pagination) Paginate(c *gin.Context) (*gorm.DB, error) {
 
 	if lastIDQuery != "" {
 		lastID, err := strconv.Atoi(lastIDQuery)
+
 		if err != nil {
 			return db, err
 		}
@@ -54,6 +61,7 @@ func (p *Pagination) Paginate(c *gin.Context) (*gorm.DB, error) {
 	}
 
 	page, err := strconv.Atoi(pageQuery)
+
 	if err != nil {
 		return db, err
 	}
@@ -63,7 +71,11 @@ func (p *Pagination) Paginate(c *gin.Context) (*gorm.DB, error) {
 	return db.Offset(limit * (p.Page - 1)).Limit(p.Limit), nil
 }
 
-func (p *Pagination) SetHeaderLink(c *gin.Context, index int) {
+func (p *Pagination) SetHeaderLink(c *gin.Context, index int) error {
+	if p == nil {
+		return errors.New("Pagination struct got nil.")
+	}
+
 	var link string
 
 	if p.LastID != 0 {
@@ -80,4 +92,5 @@ func (p *Pagination) SetHeaderLink(c *gin.Context, index int) {
 	}
 
 	c.Header("Link", link)
+	return nil
 }

--- a/_templates/controller.go.tmpl
+++ b/_templates/controller.go.tmpl
@@ -14,6 +14,7 @@ import (
 
 func Get{{ pluralize .Model.Name }}(c *gin.Context) {
 	ver, err := version.New(c)
+
 	if err != nil {
 		c.JSON(400, gin.H{"error": err.Error()})
 		return
@@ -51,7 +52,11 @@ func Get{{ pluralize .Model.Name }}(c *gin.Context) {
 	} else {
 		index = int({{ pluralize (tolower .Model.Name) }}[len({{ pluralize (tolower .Model.Name) }})-1].ID)
 	}
-	pagination.SetHeaderLink(c, index)
+
+	if err := pagination.SetHeaderLink(c, index); err != nil {
+		c.JSON(400, gin.H{"error": err.Error()})
+		return
+	}
 
 	if version.Range("1.0.0", "<=", ver) && version.Range(ver, "<", "2.0.0") {
 		// conditional branch by version.

--- a/_templates/skeleton/db/pagination.go.tmpl
+++ b/_templates/skeleton/db/pagination.go.tmpl
@@ -76,16 +76,20 @@ func (p *Pagination) SetHeaderLink(c *gin.Context, index int) error {
 		return errors.New("Pagination struct got nil.")
 	}
 
-	var link string
+	reqScheme := "http"
 
-	if p.LastID != 0 {
-		link = fmt.Sprintf("<http://%v%v?limit=%v&last_id=%v&order=%v>; rel=\"next\"", c.Request.Host, c.Request.URL.Path, p.Limit, index, p.Order)
-	} else {
+	if c.Request.TLS != nil {
+		reqScheme = "https"
+	}
+
+	link := fmt.Sprintf("<%s://%v%v?limit=%v&last_id=%v&order=%v>; rel=\"next\"", reqScheme, c.Request.Host, c.Request.URL.Path, p.Limit, index, p.Order)
+
+	if p.LastID == 0 {
 		if p.Page == 1 {
-			link = fmt.Sprintf("<http://%v%v?limit=%v&page=%v>; rel=\"next\"", c.Request.Host, c.Request.URL.Path, p.Limit, p.Page+1)
+			link = fmt.Sprintf("<%s://%v%v?limit=%v&page=%v>; rel=\"next\"", reqScheme, c.Request.Host, c.Request.URL.Path, p.Limit, p.Page+1)
 		} else {
 			link = fmt.Sprintf(
-				"<http://%v%v?limit=%v&page=%v>; rel=\"next\",<http://%v%v?limit=%v&page=%v>; rel=\"prev\"",
+				"<%s://%v%v?limit=%v&page=%v>; rel=\"next\",<http://%v%v?limit=%v&page=%v>; rel=\"prev\"", reqScheme,
 				c.Request.Host, c.Request.URL.Path, p.Limit, p.Page+1, c.Request.Host, c.Request.URL.Path, p.Limit, p.Page-1,
 			)
 		}

--- a/_templates/skeleton/db/pagination.go.tmpl
+++ b/_templates/skeleton/db/pagination.go.tmpl
@@ -1,6 +1,7 @@
 package db
 
 import (
+	"errors"
 	"fmt"
 	"math"
 	"strconv"
@@ -24,6 +25,10 @@ type Pagination struct {
 }
 
 func (p *Pagination) Paginate(c *gin.Context) (*gorm.DB, error) {
+	if p == nil {
+		return nil, errors.New("Pagination struct got nil.")
+	}
+
 	db := DBInstance(c)
 	limitQuery := c.DefaultQuery("limit", defaultLimit)
 	pageQuery := c.DefaultQuery("page", defaultPage)
@@ -32,6 +37,7 @@ func (p *Pagination) Paginate(c *gin.Context) (*gorm.DB, error) {
 	p.Order = c.DefaultQuery("order", defaultOrder)
 
 	limit, err := strconv.Atoi(limitQuery)
+
 	if err != nil {
 		return db, err
 	}
@@ -40,6 +46,7 @@ func (p *Pagination) Paginate(c *gin.Context) (*gorm.DB, error) {
 
 	if lastIDQuery != "" {
 		lastID, err := strconv.Atoi(lastIDQuery)
+
 		if err != nil {
 			return db, err
 		}
@@ -54,6 +61,7 @@ func (p *Pagination) Paginate(c *gin.Context) (*gorm.DB, error) {
 	}
 
 	page, err := strconv.Atoi(pageQuery)
+
 	if err != nil {
 		return db, err
 	}
@@ -63,7 +71,11 @@ func (p *Pagination) Paginate(c *gin.Context) (*gorm.DB, error) {
 	return db.Offset(limit * (p.Page - 1)).Limit(p.Limit), nil
 }
 
-func (p *Pagination) SetHeaderLink(c *gin.Context, index int) {
+func (p *Pagination) SetHeaderLink(c *gin.Context, index int) error {
+	if p == nil {
+		return errors.New("Pagination struct got nil.")
+	}
+
 	var link string
 
 	if p.LastID != 0 {
@@ -80,4 +92,5 @@ func (p *Pagination) SetHeaderLink(c *gin.Context, index int) {
 	}
 
 	c.Header("Link", link)
+	return nil
 }

--- a/apig/testdata/controllers/user.go
+++ b/apig/testdata/controllers/user.go
@@ -14,6 +14,7 @@ import (
 
 func GetUsers(c *gin.Context) {
 	ver, err := version.New(c)
+
 	if err != nil {
 		c.JSON(400, gin.H{"error": err.Error()})
 		return
@@ -51,7 +52,11 @@ func GetUsers(c *gin.Context) {
 	} else {
 		index = int(users[len(users)-1].ID)
 	}
-	pagination.SetHeaderLink(c, index)
+
+	if err := pagination.SetHeaderLink(c, index); err != nil {
+		c.JSON(400, gin.H{"error": err.Error()})
+		return
+	}
 
 	if version.Range("1.0.0", "<=", ver) && version.Range(ver, "<", "2.0.0") {
 		// conditional branch by version.


### PR DESCRIPTION
## WHY
Struct `pagination` has `pointer` receivers. 
This method may cause panics if this function is called without being initialized.

## WHAT
- Add error handlings.
- Check `http` or `https` in pagination link.