### PR TITLE
Refactor generate.Generate function (again)

### DIFF
--- a/apig/generate.go
+++ b/apig/generate.go
@@ -559,26 +559,32 @@ func Generate(outDir, modelDir, targetFile string, all bool) int {
 			return 1
 		}
 	}
+
 	if err := generateRootController(detail, outDir); err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		return 1
 	}
+
 	if err := generateApibIndex(detail, outDir); err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		return 1
 	}
+
 	if err := generateRouter(detail, outDir); err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		return 1
 	}
+
 	if err := generateDB(detail, outDir); err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		return 1
 	}
+
 	if err := generateREADME(detail, outDir); err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		return 1
 	}
+
 	fmt.Println("===> Generated...")
 	return 0
 }


### PR DESCRIPTION
Try again #67 

## WHY
Now `generate.Generate` function has [167 lines](https://github.com/wantedly/apig/blob/master/apig/generate.go#L389-L556). This is so fat and its logic is complex.
Additionally, it seems that there are some unnecessary goroutines.

## WHAT
Extract some logic to another funcitons. Lines are reduced up to 90 lines.
Remove unnecessary goroutines.