### PR TITLE
Return JSON objects in streaming format

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,7 @@ Resource name is written in the plural form.
 
 |Parameter|Description|Default|Example|
 |---------|-----------|-------|-------|
+|`stream=`|Return JSON in streaming format|`false`|`true`|
 |`ids=`|Item IDs|(empty)|`1,2,5`|
 |`limit=`|Maximum number of items|`25`|`50`|
 |`page=`|Page to receive|`1`|`3`|

--- a/_example/controllers/company.go
+++ b/_example/controllers/company.go
@@ -1,6 +1,7 @@
 package controllers
 
 import (
+	"encoding/json"
 	"net/http"
 	"strings"
 
@@ -46,19 +47,6 @@ func GetCompanies(c *gin.Context) {
 		return
 	}
 
-	fieldMaps := []map[string]interface{}{}
-
-	for _, company := range companies {
-		fieldMap, err := helper.FieldToMap(company, fields)
-
-		if err != nil {
-			c.JSON(400, gin.H{"error": err.Error()})
-			return
-		}
-
-		fieldMaps = append(fieldMaps, fieldMap)
-	}
-
 	index := 0
 
 	if len(companies) > 0 {
@@ -75,10 +63,42 @@ func GetCompanies(c *gin.Context) {
 		// 1.0.0 <= this version < 2.0.0 !!
 	}
 
-	if _, ok := c.GetQuery("pretty"); ok {
-		c.IndentedJSON(200, fieldMaps)
+	if _, ok := c.GetQuery("stream"); ok {
+		enc := json.NewEncoder(c.Writer)
+		c.Status(200)
+
+		for _, company := range companies {
+			fieldMap, err := helper.FieldToMap(company, fields)
+
+			if err != nil {
+				c.JSON(400, gin.H{"error": err.Error()})
+				return
+			}
+
+			if err := enc.Encode(fieldMap); err != nil {
+				c.JSON(400, gin.H{"error": err.Error()})
+				return
+			}
+		}
 	} else {
-		c.JSON(200, fieldMaps)
+		fieldMaps := []map[string]interface{}{}
+
+		for _, company := range companies {
+			fieldMap, err := helper.FieldToMap(company, fields)
+
+			if err != nil {
+				c.JSON(400, gin.H{"error": err.Error()})
+				return
+			}
+
+			fieldMaps = append(fieldMaps, fieldMap)
+		}
+
+		if _, ok := c.GetQuery("pretty"); ok {
+			c.IndentedJSON(200, fieldMaps)
+		} else {
+			c.JSON(200, fieldMaps)
+		}
 	}
 }
 

--- a/_example/controllers/email.go
+++ b/_example/controllers/email.go
@@ -1,6 +1,7 @@
 package controllers
 
 import (
+	"encoding/json"
 	"net/http"
 	"strings"
 
@@ -46,19 +47,6 @@ func GetEmails(c *gin.Context) {
 		return
 	}
 
-	fieldMaps := []map[string]interface{}{}
-
-	for _, email := range emails {
-		fieldMap, err := helper.FieldToMap(email, fields)
-
-		if err != nil {
-			c.JSON(400, gin.H{"error": err.Error()})
-			return
-		}
-
-		fieldMaps = append(fieldMaps, fieldMap)
-	}
-
 	index := 0
 
 	if len(emails) > 0 {
@@ -75,10 +63,42 @@ func GetEmails(c *gin.Context) {
 		// 1.0.0 <= this version < 2.0.0 !!
 	}
 
-	if _, ok := c.GetQuery("pretty"); ok {
-		c.IndentedJSON(200, fieldMaps)
+	if _, ok := c.GetQuery("stream"); ok {
+		enc := json.NewEncoder(c.Writer)
+		c.Status(200)
+
+		for _, email := range emails {
+			fieldMap, err := helper.FieldToMap(email, fields)
+
+			if err != nil {
+				c.JSON(400, gin.H{"error": err.Error()})
+				return
+			}
+
+			if err := enc.Encode(fieldMap); err != nil {
+				c.JSON(400, gin.H{"error": err.Error()})
+				return
+			}
+		}
 	} else {
-		c.JSON(200, fieldMaps)
+		fieldMaps := []map[string]interface{}{}
+
+		for _, email := range emails {
+			fieldMap, err := helper.FieldToMap(email, fields)
+
+			if err != nil {
+				c.JSON(400, gin.H{"error": err.Error()})
+				return
+			}
+
+			fieldMaps = append(fieldMaps, fieldMap)
+		}
+
+		if _, ok := c.GetQuery("pretty"); ok {
+			c.IndentedJSON(200, fieldMaps)
+		} else {
+			c.JSON(200, fieldMaps)
+		}
 	}
 }
 

--- a/_example/controllers/job.go
+++ b/_example/controllers/job.go
@@ -1,6 +1,7 @@
 package controllers
 
 import (
+	"encoding/json"
 	"net/http"
 	"strings"
 
@@ -46,19 +47,6 @@ func GetJobs(c *gin.Context) {
 		return
 	}
 
-	fieldMaps := []map[string]interface{}{}
-
-	for _, job := range jobs {
-		fieldMap, err := helper.FieldToMap(job, fields)
-
-		if err != nil {
-			c.JSON(400, gin.H{"error": err.Error()})
-			return
-		}
-
-		fieldMaps = append(fieldMaps, fieldMap)
-	}
-
 	index := 0
 
 	if len(jobs) > 0 {
@@ -75,10 +63,42 @@ func GetJobs(c *gin.Context) {
 		// 1.0.0 <= this version < 2.0.0 !!
 	}
 
-	if _, ok := c.GetQuery("pretty"); ok {
-		c.IndentedJSON(200, fieldMaps)
+	if _, ok := c.GetQuery("stream"); ok {
+		enc := json.NewEncoder(c.Writer)
+		c.Status(200)
+
+		for _, job := range jobs {
+			fieldMap, err := helper.FieldToMap(job, fields)
+
+			if err != nil {
+				c.JSON(400, gin.H{"error": err.Error()})
+				return
+			}
+
+			if err := enc.Encode(fieldMap); err != nil {
+				c.JSON(400, gin.H{"error": err.Error()})
+				return
+			}
+		}
 	} else {
-		c.JSON(200, fieldMaps)
+		fieldMaps := []map[string]interface{}{}
+
+		for _, job := range jobs {
+			fieldMap, err := helper.FieldToMap(job, fields)
+
+			if err != nil {
+				c.JSON(400, gin.H{"error": err.Error()})
+				return
+			}
+
+			fieldMaps = append(fieldMaps, fieldMap)
+		}
+
+		if _, ok := c.GetQuery("pretty"); ok {
+			c.IndentedJSON(200, fieldMaps)
+		} else {
+			c.JSON(200, fieldMaps)
+		}
 	}
 }
 

--- a/_example/controllers/user.go
+++ b/_example/controllers/user.go
@@ -1,6 +1,7 @@
 package controllers
 
 import (
+	"encoding/json"
 	"net/http"
 	"strings"
 
@@ -46,19 +47,6 @@ func GetUsers(c *gin.Context) {
 		return
 	}
 
-	fieldMaps := []map[string]interface{}{}
-
-	for _, user := range users {
-		fieldMap, err := helper.FieldToMap(user, fields)
-
-		if err != nil {
-			c.JSON(400, gin.H{"error": err.Error()})
-			return
-		}
-
-		fieldMaps = append(fieldMaps, fieldMap)
-	}
-
 	index := 0
 
 	if len(users) > 0 {
@@ -75,10 +63,42 @@ func GetUsers(c *gin.Context) {
 		// 1.0.0 <= this version < 2.0.0 !!
 	}
 
-	if _, ok := c.GetQuery("pretty"); ok {
-		c.IndentedJSON(200, fieldMaps)
+	if _, ok := c.GetQuery("stream"); ok {
+		enc := json.NewEncoder(c.Writer)
+		c.Status(200)
+
+		for _, user := range users {
+			fieldMap, err := helper.FieldToMap(user, fields)
+
+			if err != nil {
+				c.JSON(400, gin.H{"error": err.Error()})
+				return
+			}
+
+			if err := enc.Encode(fieldMap); err != nil {
+				c.JSON(400, gin.H{"error": err.Error()})
+				return
+			}
+		}
 	} else {
-		c.JSON(200, fieldMaps)
+		fieldMaps := []map[string]interface{}{}
+
+		for _, user := range users {
+			fieldMap, err := helper.FieldToMap(user, fields)
+
+			if err != nil {
+				c.JSON(400, gin.H{"error": err.Error()})
+				return
+			}
+
+			fieldMaps = append(fieldMaps, fieldMap)
+		}
+
+		if _, ok := c.GetQuery("pretty"); ok {
+			c.IndentedJSON(200, fieldMaps)
+		} else {
+			c.JSON(200, fieldMaps)
+		}
 	}
 }
 

--- a/_templates/controller.go.tmpl
+++ b/_templates/controller.go.tmpl
@@ -1,6 +1,7 @@
 package controllers
 
 import (
+	"encoding/json"
 	"net/http"
 	"strings"
 
@@ -46,19 +47,6 @@ func Get{{ pluralize .Model.Name }}(c *gin.Context) {
 		return
 	}
 
-	fieldMaps := []map[string]interface{}{}
-
-	for _, {{ toLowerCamelCase .Model.Name }} := range {{ pluralize (toLowerCamelCase .Model.Name) }} {
-		fieldMap, err := helper.FieldToMap({{ toLowerCamelCase .Model.Name }}, fields)
-
-		if err != nil {
-			c.JSON(400, gin.H{"error": err.Error()})
-			return
-		}
-
-		fieldMaps = append(fieldMaps, fieldMap)
-	}
-
 	index := 0
 
 	if len({{ pluralize (toLowerCamelCase .Model.Name) }}) > 0 {
@@ -75,10 +63,42 @@ func Get{{ pluralize .Model.Name }}(c *gin.Context) {
 		// 1.0.0 <= this version < 2.0.0 !!
 	}
 
-	if _, ok := c.GetQuery("pretty"); ok {
-		c.IndentedJSON(200, fieldMaps)
+	if _, ok := c.GetQuery("stream"); ok {
+		enc := json.NewEncoder(c.Writer)
+		c.Status(200)
+
+		for _, {{ toLowerCamelCase .Model.Name }} := range {{ pluralize (toLowerCamelCase .Model.Name) }} {
+			fieldMap, err := helper.FieldToMap({{ toLowerCamelCase .Model.Name }}, fields)
+
+			if err != nil {
+				c.JSON(400, gin.H{"error": err.Error()})
+				return
+			}
+
+			if err := enc.Encode(fieldMap); err != nil {
+				c.JSON(400, gin.H{"error": err.Error()})
+				return
+			}
+		}
 	} else {
-		c.JSON(200, fieldMaps)
+		fieldMaps := []map[string]interface{}{}
+
+		for _, {{ toLowerCamelCase .Model.Name }} := range {{ pluralize (toLowerCamelCase .Model.Name) }} {
+			fieldMap, err := helper.FieldToMap({{ toLowerCamelCase .Model.Name }}, fields)
+
+			if err != nil {
+				c.JSON(400, gin.H{"error": err.Error()})
+				return
+			}
+
+			fieldMaps = append(fieldMaps, fieldMap)
+		}
+
+		if _, ok := c.GetQuery("pretty"); ok {
+			c.IndentedJSON(200, fieldMaps)
+		} else {
+			c.JSON(200, fieldMaps)
+		}
 	}
 }
 

--- a/apig/testdata/controllers/user.go
+++ b/apig/testdata/controllers/user.go
@@ -1,6 +1,7 @@
 package controllers
 
 import (
+	"encoding/json"
 	"net/http"
 	"strings"
 
@@ -46,19 +47,6 @@ func GetUsers(c *gin.Context) {
 		return
 	}
 
-	fieldMaps := []map[string]interface{}{}
-
-	for _, user := range users {
-		fieldMap, err := helper.FieldToMap(user, fields)
-
-		if err != nil {
-			c.JSON(400, gin.H{"error": err.Error()})
-			return
-		}
-
-		fieldMaps = append(fieldMaps, fieldMap)
-	}
-
 	index := 0
 
 	if len(users) > 0 {
@@ -75,10 +63,42 @@ func GetUsers(c *gin.Context) {
 		// 1.0.0 <= this version < 2.0.0 !!
 	}
 
-	if _, ok := c.GetQuery("pretty"); ok {
-		c.IndentedJSON(200, fieldMaps)
+	if _, ok := c.GetQuery("stream"); ok {
+		enc := json.NewEncoder(c.Writer)
+		c.Status(200)
+
+		for _, user := range users {
+			fieldMap, err := helper.FieldToMap(user, fields)
+
+			if err != nil {
+				c.JSON(400, gin.H{"error": err.Error()})
+				return
+			}
+
+			if err := enc.Encode(fieldMap); err != nil {
+				c.JSON(400, gin.H{"error": err.Error()})
+				return
+			}
+		}
 	} else {
-		c.JSON(200, fieldMaps)
+		fieldMaps := []map[string]interface{}{}
+
+		for _, user := range users {
+			fieldMap, err := helper.FieldToMap(user, fields)
+
+			if err != nil {
+				c.JSON(400, gin.H{"error": err.Error()})
+				return
+			}
+
+			fieldMaps = append(fieldMaps, fieldMap)
+		}
+
+		if _, ok := c.GetQuery("pretty"); ok {
+			c.IndentedJSON(200, fieldMaps)
+		} else {
+			c.JSON(200, fieldMaps)
+		}
 	}
 }
 


### PR DESCRIPTION
## WHAT
- Using `?stream` parameter, return JSON objects in streaming format.

## HOW
ref.) https://en.wikipedia.org/wiki/JSON_Streaming

- Line delimited JSON format.

```
{"account_name":null,"created_at":"2016-09-12T17:27:36.135532037+09:00","emails":null,"id":1,"name":"test1","updated_at":"2016-09-12T17:27:36.135532037+09:00"}
{"account_name":null,"created_at":"2016-09-12T17:27:37.353012323+09:00","emails":null,"id":2,"name":"test2","updated_at":"2016-09-12T17:27:37.353012323+09:00"}
{"account_name":null,"created_at":"2016-09-12T17:27:38.194750274+09:00","emails":null,"id":3,"name":"test3","updated_at":"2016-09-12T17:27:38.194750274+09:00"}
```