### PR TITLE
Modify API Blueprint link to appropriate one

### DIFF
--- a/_templates/index.apib.tmpl
+++ b/_templates/index.apib.tmpl
@@ -3,4 +3,4 @@ HOST: http://localhost:8080
 
 # {{ title .Project }} API
 {{ range .Models }}
-<!-- include({{ toLower .Name }}.apib) -->{{ end }}
+<!-- include({{ toSnakeCase .Name }}.apib) -->{{ end }}


### PR DESCRIPTION
## WHY

If model name is composited by multiple words, incorrect hyperlink is generated in API blueprint index page.

for example: company_page model -> link to ❌  `companypage.apib` ⭕ `company_page.apib`

## WHAT

Generate correct link to model API blueprint page