### PR TITLE
Omit path/filepath when DB engine is PostgreSQL

### DIFF
--- a/_templates/db.go.tmpl
+++ b/_templates/db.go.tmpl
@@ -16,15 +16,18 @@ import (
 )
 
 func Connect() *gorm.DB {
-{{ if (eq .Database "sqlite") }}	dir := filepath.Dir("db/database.db")
+{{ if (eq .Database "sqlite") -}}
+	dir := filepath.Dir("db/database.db")
 	db, err := gorm.Open("sqlite3", dir+"/database.db")
-{{ else if (eq .Database "postgres") }}	dbURL := os.Getenv("DATABASE_URL")
+{{ else if (eq .Database "postgres") -}}
+	dbURL := os.Getenv("DATABASE_URL")
 	if dbURL == "" {
 		return nil
 	}
 
 	db, err := gorm.Open("postgres", dbURL)
-{{ end }}	if err != nil {
+{{ end -}}
+	if err != nil {
 		log.Fatalf("Got error when connect database, the error is '%v'", err)
 	}
 

--- a/_templates/db.go.tmpl
+++ b/_templates/db.go.tmpl
@@ -3,7 +3,8 @@ package db
 import (
 	"log"
 	"os"
-	"path/filepath"
+{{ if (eq .Database "sqlite") }}	"path/filepath"
+{{ end -}}
 	"strings"
 
 	"{{ .ImportDir }}/models"

--- a/_templates/skeleton/db/db.go.tmpl
+++ b/_templates/skeleton/db/db.go.tmpl
@@ -14,8 +14,17 @@ import (
 )
 
 func Connect() *gorm.DB {
+{{ if (eq .Database "sqlite") -}}
 	dir := filepath.Dir("db/database.db")
 	db, err := gorm.Open("sqlite3", dir+"/database.db")
+{{ else if (eq .Database "postgres") -}}
+	dbURL := os.Getenv("DATABASE_URL")
+	if dbURL == "" {
+		return nil
+	}
+
+	db, err := gorm.Open("postgres", dbURL)
+{{ end -}}
 	if err != nil {
 		log.Fatalf("Got error when connect database, the error is '%v'", err)
 	}

--- a/_templates/skeleton/db/db.go.tmpl
+++ b/_templates/skeleton/db/db.go.tmpl
@@ -3,7 +3,8 @@ package db
 import (
 	"log"
 	"os"
-	"path/filepath"
+	{{ if (eq .Database "sqlite") }}	"path/filepath"
+	{{ end -}}
 	"strings"
 
 	"github.com/gin-gonic/gin"

--- a/apig/testdata/db/db_postgres.go
+++ b/apig/testdata/db/db_postgres.go
@@ -3,7 +3,6 @@ package db
 import (
 	"log"
 	"os"
-	"path/filepath"
 	"strings"
 
 	"github.com/wantedly/api-server/models"


### PR DESCRIPTION
## WHY
`path/filepath` library is required by `sqlite` library. However, API server still imports `path/filepath` even if DB engine is PostgreSQL.

## WHAT
Do not import `path/filepath` when DB engine is PostgreSQL.