### PR TITLE
Refactor skeleton

### DIFF
--- a/apig/skeleton.go
+++ b/apig/skeleton.go
@@ -15,12 +15,13 @@ import (
 	"github.com/wantedly/apig/util"
 )
 
+var r = regexp.MustCompile(`_templates/skeleton/.*\.tmpl$`)
+
 func generateSkeleton(detail *Detail, outDir string) error {
 	var wg sync.WaitGroup
 	errCh := make(chan error, 1)
 	done := make(chan bool, 1)
 
-	r := regexp.MustCompile(`_templates/skeleton/.*\.tmpl$`)
 	for _, skeleton := range AssetNames() {
 		wg.Add(1)
 		go func(s string) {


### PR DESCRIPTION
## WHY

Similar to #94, `skeleton.go` has unnecessary goroutine out of loop.
In addition, regular expression is compiled at every time of calling `generateSkeleton`.

## WHAT

Remove unnecessary goroutine, store regexp in global variable to be cached.