### PR TITLE
Use mutex for message output

### DIFF
--- a/msg/msg.go
+++ b/msg/msg.go
@@ -2,18 +2,26 @@ package msg
 
 import (
 	"fmt"
+	"sync"
 )
 
-var Mute = false
+var (
+	Mute = false
+	m    sync.Mutex
+)
 
 func Printf(format string, a ...interface{}) {
 	if !Mute {
+		m.Lock()
 		fmt.Printf(format, a...)
+		m.Unlock()
 	}
 }
 
 func Println(a ...interface{}) {
 	if !Mute {
+		m.Lock()
 		fmt.Println(a...)
+		m.Unlock()
 	}
 }


### PR DESCRIPTION
## WHY

Generation of controllers, documents, and so on are running concurrently. Due to this, some of output messages are collapsed.

```
        create /Users/dtan4/src/github.com/dtan4/api-server/controllers/user.go
        create /Users/dtan4/src/github.com/dtan4/api-server/docs/compant.apib
        create /Users/dtan4/src/github.com/dtan4/api-server/docs/job.apib
        create  create /Users/dtan4/src/github.com/dtan4/api-server/controllers/company.go
        create /Users/dtan4/src/github.com/dtan4/api-server/controllers/job.go
 /Users/dtan4/src/github.com/dtan4/api-server/controllers/email.go
        create /Users/dtan4/src/github.com/dtan4/api-server/controllers/occupation.go
        create /Users/dtan4/src/github.com/dtan4/api-server/docs/recipe.apib
        create /Users/dtan4/src/github.com/dtan4/api-server/docs/project.apib
        create /Users/dtan4/src/github.com/dtan4/api-server/docs/occupation.apib
        create /Users/dtan4/src/github.com/dtan4/api-server/docs/user.apib
```

## WHAT

Introduce Mutex to serialize message outputs. 2 or more message output processes are not occurred simultaneously.