### PR TITLE
DB name is missing

### DIFF
--- a/_templates/skeleton/db/db.go.tmpl
+++ b/_templates/skeleton/db/db.go.tmpl
@@ -9,7 +9,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/jinzhu/gorm"
-	_ "github.com/jinzhu/gorm/dialects/sqlite"
+	_ "github.com/jinzhu/gorm/dialects/{{ .Database }}"
 	"github.com/serenize/snaker"
 )
 

--- a/apig/generate.go
+++ b/apig/generate.go
@@ -607,6 +607,12 @@ func Generate(outDir, modelDir, targetFile string, all bool) int {
 		return 1
 	}
 
+	database, err := detectDatabase(outDir)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return 1
+	}
+
 	detail := &Detail{
 		Models:    models,
 		ImportDir: importDir,
@@ -614,6 +620,7 @@ func Generate(outDir, modelDir, targetFile string, all bool) int {
 		User:      user,
 		Project:   project,
 		Namespace: namespace,
+		Database:  database,
 	}
 
 	if err := generateCommonFiles(detail, outDir); err != nil {
@@ -622,14 +629,6 @@ func Generate(outDir, modelDir, targetFile string, all bool) int {
 	}
 
 	if all {
-		database, err := detectDatabase(outDir)
-		if err != nil {
-			fmt.Fprintln(os.Stderr, err)
-			return 1
-		}
-
-		detail.Database = database
-
 		if err := generateSkeleton(detail, outDir); err != nil {
 			fmt.Fprintln(os.Stderr, err)
 			return 1

--- a/apig/skeleton.go
+++ b/apig/skeleton.go
@@ -3,6 +3,7 @@ package apig
 import (
 	"bytes"
 	"fmt"
+	"go/format"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -46,9 +47,19 @@ func generateSkeleton(detail *Detail, outDir string) error {
 			}
 
 			var buf bytes.Buffer
+			var src []byte
 
 			if err := tmpl.Execute(&buf, detail); err != nil {
 				errCh <- err
+			}
+
+			if strings.HasSuffix(path, ".go") {
+				src, err = format.Source(buf.Bytes())
+				if err != nil {
+					errCh <- err
+				}
+			} else {
+				src = buf.Bytes()
 			}
 
 			if !util.FileExists(filepath.Dir(dstPath)) {
@@ -57,7 +68,7 @@ func generateSkeleton(detail *Detail, outDir string) error {
 				}
 			}
 
-			if err := ioutil.WriteFile(dstPath, buf.Bytes(), 0644); err != nil {
+			if err := ioutil.WriteFile(dstPath, src, 0644); err != nil {
 				errCh <- err
 			}
 


### PR DESCRIPTION
## WHY
- database name, `sqllite, postgres` is missing.

```go
import (
	"github.com/jinzhu/gorm"
	_ "github.com/jinzhu/gorm/dialects/"
)
```

## WHAT
- Function `generateDB` needs `detail.Database`. So call function `detectDatabase` when `apig gen` runs.
- Format skeleton template files.