### PR TITLE
fix gorm.Model support

### DIFF
--- a/apig/parse.go
+++ b/apig/parse.go
@@ -11,11 +11,10 @@ import (
 )
 
 func parseField(field *ast.Field) (*Field, error) {
-	if len(field.Names) != 1 {
-		return nil, errors.New("Failed to read model files. Please fix struct.")
+	fieldName := ""
+	if len(field.Names) == 1 {
+		fieldName = field.Names[0].Name
 	}
-
-	fieldName := field.Names[0].Name
 
 	var fieldType string
 
@@ -52,6 +51,11 @@ func parseField(field *ast.Field) (*Field, error) {
 				fieldType = "*" + x3.Name + "." + x2.Sel.Name
 			}
 		}
+	}
+
+	//for now only unnamed field we can handle is gorm.Model, maybe expand this later
+	if len(field.Names) != 1 && fieldType != "gorm.Model" {
+		return nil, errors.New("Failed to read model files. Please fix struct.")
 	}
 
 	var jsonName string
@@ -124,10 +128,10 @@ func parseModel(path string) ([]*Model, error) {
 						Name:   modelName,
 						Fields: fields,
 					})
+
 				}
 			}
 		}
-
 		return true
 	})
 

--- a/apig/parse_test.go
+++ b/apig/parse_test.go
@@ -70,6 +70,44 @@ func TestParseModel(t *testing.T) {
 	}
 }
 
+func TestParseComplexModels(t *testing.T) {
+	path := filepath.Join("testdata", "parse", "complex_models.go")
+
+	models, err := parseModel(path)
+
+	if err != nil {
+		t.Fatalf("Failed to parse model file. error: %s", err)
+	}
+
+	if len(models) != 2 {
+		t.Fatalf("Number of parsed models is incorrect. expected: 2, actual: %d", len(models))
+	}
+
+	user := models[0]
+
+	if user.Name != "User" {
+		t.Fatalf("Incorrect model name. expected: User, actual: %s", user.Name)
+	}
+
+	expectedFields := []*Field{
+		&Field{
+			Name:     "",
+			JSONName: "",
+			Type:     "gorm.Model",
+		},
+		&Field{
+			Name:     "Name",
+			JSONName: "name",
+			Type:     "string",
+		},
+	}
+
+	for i, actual := range user.Fields {
+		if !fieldEquals(expectedFields[i], actual) {
+			t.Fatalf("Incorrect field. expected: %#v, actual: %#v", expectedFields[i], actual)
+		}
+	}
+}
 func TestParseImport(t *testing.T) {
 	path := filepath.Join("testdata", "parse", "router.go")
 

--- a/apig/testdata/parse/complex_models.go
+++ b/apig/testdata/parse/complex_models.go
@@ -1,0 +1,15 @@
+package model
+
+import "github.com/jinzhu/gorm"
+
+type User struct {
+	gorm.Model
+
+	Name string `json:"name,omitempty" form:"name"`
+}
+
+type Job struct {
+	gorm.Model
+	Name        string `json:"name,omitempty" form:"name"`
+	Description string `json:"description,omitempty" form:"description"`
+}


### PR DESCRIPTION
Idiotmatic Form means you should embed the "gorm.Model" in your struct. However this breaks the parser for apig. I fixed the parser for this case, but kept it quite narrow in scope for now

type User struct {
	gorm.Model
	Email string `json:"email" form:"email"`
}
